### PR TITLE
Remove pycuda and rely on nvidia-smi output to detect CUDA version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maritalk"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
   { name="Maritaca AI", email="info@maritaca.ai" },
 ]


### PR DESCRIPTION
Remove pycuda and warn the user if we couldn't automatically detect the current device compute capability. In this case, the user can bypass the automatic detection and set the version manually.