### PR TITLE
Add download and start commands

### DIFF
--- a/README-Local.md
+++ b/README-Local.md
@@ -63,14 +63,32 @@ print(chat_response)  # {'output': 'nani, bento e leo.', 'queue_time': 0, 'promp
 
 O retorno das chamadas contém o texto gerado e os tempos de espera, de execução do prompt e da geração do texto para fins de debug do usuário.
 
+Também existem 2 comandos para facilitar o gerenciamento do executável:
 
-## Executando o binário diretamente
+#### Download
 
-Também é possivel executar o servidor diretamente no terminal, sem o wrapper em python.
+Para fazer o download do exectuável para um determinado path, você pode executar:
+
+```console
+$ python -m maritalk.download --license <SUA LICENÇA> --path maritalk-small
+```
+
+#### Start
+
+Para fazer o download automaticamente e iniciar o servidor da MariTalk Local, você pode executar:
+
+```console
+$ python -m maritalk.start --license <SUA LICENÇA>
+```
+
+
+## Iniciando o executável diretamente
+
+Também é possivel executar o servidor diretamente no terminal, sem o wrapper em Python.
 
 #### Download
 ```bash
-wget -O maritalk <link do binário recebido no email> 
+wget -O maritalk <link do exectuável recebido no email>
 ```
 
 #### Dependências

--- a/README-Local.md
+++ b/README-Local.md
@@ -88,7 +88,7 @@ Também é possivel executar o servidor diretamente no terminal, sem o wrapper e
 
 #### Download
 ```bash
-wget -O maritalk <link do exectuável recebido no email>
+wget -O maritalk <link do executável recebido no email>
 ```
 
 #### Dependências

--- a/maritalk/download.py
+++ b/maritalk/download.py
@@ -2,20 +2,34 @@ import os
 import argparse
 from .resources.local import download, check_gpu, find_libs
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Start MariTalk Local server.")
-    parser.add_argument('--license', type=str, required=True, help='License key for downloading the model.')
-    parser.add_argument('--path', type=str, default='~/bin/maritalk', help='Path to save the executable.')
-    parser.add_argument('--cuda', type=int, choices=[11, 12], default=None, help='Installed CUDA version.')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Download MariTalk Local server.")
+    parser.add_argument(
+        "--license",
+        type=str,
+        required=True,
+        help="License key for downloading the model.",
+    )
+    parser.add_argument(
+        "--path",
+        type=str,
+        default="~/bin/maritalk",
+        help="Path to save the executable.",
+    )
+    parser.add_argument(
+        "--cuda",
+        type=int,
+        choices=[11, 12],
+        default=None,
+        help="Installed CUDA version.",
+    )
     args = parser.parse_args()
 
     if not args.cuda:
         check_gpu()
     detected_versions = find_libs()
 
-    dependencies = {
-        "cuda_version": args.cuda or detected_versions["cuda_version"]
-    }
+    dependencies = {"cuda_version": args.cuda or detected_versions["cuda_version"]}
 
     if dependencies["cuda_version"] is None:
         raise Exception(

--- a/maritalk/download.py
+++ b/maritalk/download.py
@@ -1,0 +1,28 @@
+import os
+import argparse
+from .resources.local import download, check_gpu, find_libs
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Start MariTalk Local server.")
+    parser.add_argument('--license', type=str, required=True, help='License key for downloading the model.')
+    parser.add_argument('--path', type=str, default='~/bin/maritalk', help='Path to save the executable.')
+    parser.add_argument('--cuda', type=int, choices=[11, 12], default=None, help='Installed CUDA version.')
+    args = parser.parse_args()
+
+    if not args.cuda:
+        check_gpu()
+    detected_versions = find_libs()
+
+    dependencies = {
+        "cuda_version": args.cuda or detected_versions["cuda_version"]
+    }
+
+    if dependencies["cuda_version"] is None:
+        raise Exception(
+            "No libcublas.so found. cuBLAS v11 or v12 is required to run MariTalk. You can manually set the version using the `cuda_version` argument."
+        )
+
+    bin_folder = os.path.dirname(args.path)
+    if bin_folder:
+        os.makedirs(bin_folder, exist_ok=True)
+    download(args.license, args.path, dependencies)

--- a/maritalk/resources/local.py
+++ b/maritalk/resources/local.py
@@ -62,52 +62,52 @@ def find_libs():
 
 
 def download(license: str, bin_path: str, dependencies: Dict[str, int]):
-        download_url = (
-            "https://m64xplb35dhr3se7ipvtmbdnk40ahktr.lambda-url.us-east-1.on.aws/"
-        )
-        response = requests.post(
-            download_url,
-            json={
-                "license": license,
-                "cuda_version": dependencies["cuda_version"],
-            },
-        )
-        if not response.ok:
-            raise Exception(response.text)
+    download_url = (
+        "https://m64xplb35dhr3se7ipvtmbdnk40ahktr.lambda-url.us-east-1.on.aws/"
+    )
+    response = requests.post(
+        download_url,
+        json={
+            "license": license,
+            "cuda_version": dependencies["cuda_version"],
+        },
+    )
+    if not response.ok:
+        raise Exception(response.text)
 
-        result = response.json()
+    result = response.json()
 
-        if "presigned_url" not in result:
-            raise ValueError(f"Failed to validate license ({license}): {result}")
+    if "presigned_url" not in result:
+        raise ValueError(f"Failed to validate license ({license}): {result}")
 
-        file_url = result["presigned_url"]
-        model_size = result["model_size"]
+    file_url = result["presigned_url"]
+    model_size = result["model_size"]
 
-        print(f"Downloading MariTalk-{model_size} (path: {bin_path})...")
+    print(f"Downloading MariTalk-{model_size} (path: {bin_path})...")
 
-        try:
-            with requests.get(file_url, stream=True) as response:
-                response.raise_for_status()
-                file_size = int(response.headers.get("content-length", 0))
-                if file_size > 0:
-                    progress_bar = tqdm(
-                        total=file_size,
-                        unit="B",
-                        unit_scale=True,
-                        desc=bin_path,
-                    )
-                    with open(bin_path, "wb") as out:
-                        for chunk in response.iter_content(chunk_size=16384):
-                            out.write(chunk)
-                            progress_bar.update(len(chunk))
+    try:
+        with requests.get(file_url, stream=True) as response:
+            response.raise_for_status()
+            file_size = int(response.headers.get("content-length", 0))
+            if file_size > 0:
+                progress_bar = tqdm(
+                    total=file_size,
+                    unit="B",
+                    unit_scale=True,
+                    desc=bin_path,
+                )
+                with open(bin_path, "wb") as out:
+                    for chunk in response.iter_content(chunk_size=16384):
+                        out.write(chunk)
+                        progress_bar.update(len(chunk))
 
-                    os.chmod(bin_path, 0o744)
-                else:
-                    raise Exception(
-                        f"Invalid response from the server while downloading: {response.text}"
-                    )
-        except requests.exceptions.RequestException as e:
-            raise Exception(f"Error downloading MariTalk binary: {e}")
+                os.chmod(bin_path, 0o744)
+            else:
+                raise Exception(
+                    f"Invalid response from the server while downloading: {response.text}"
+                )
+    except requests.exceptions.RequestException as e:
+        raise Exception(f"Error downloading MariTalk binary: {e}")
 
 
 def start_server(
@@ -160,7 +160,7 @@ class MariTalkLocal:
         cuda_version: Optional[int] = None,
     ):
         print(f"Starting MariTalk Local API at http://localhost:{self.port}")
-        self.process = start_server(license, bin_path, cuda_version)
+        self.process = start_server(license, bin_path, cuda_version, self.port)
         while True:
             try:
                 if self.process.poll() is not None:

--- a/maritalk/start.py
+++ b/maritalk/start.py
@@ -1,0 +1,21 @@
+import atexit
+import argparse
+from .resources.local import start_server
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Start MariTalk Local server.")
+    parser.add_argument('--license', type=str, required=True, help='License key for downloading the model.')
+    parser.add_argument('--path', type=str, default='~/bin/maritalk', help='Path for the executable.')
+    parser.add_argument('--cuda', type=int, choices=[11, 12], default=None, help='Installed CUDA version.')
+    parser.add_argument('--port', type=int, default=9000, help='The HTTP port to bind.')
+    args = parser.parse_args()
+
+    process = start_server(args.license, args.path, args.cuda, args.port)
+    atexit.register(lambda: process.terminate())
+
+    while True:
+        output = process.stdout.readline()
+        if process.poll() is not None and output == b'':
+            break
+        if output:
+            print(output.decode().strip())

--- a/maritalk/start.py
+++ b/maritalk/start.py
@@ -2,12 +2,25 @@ import atexit
 import argparse
 from .resources.local import start_server
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Start MariTalk Local server.")
-    parser.add_argument('--license', type=str, required=True, help='License key for downloading the model.')
-    parser.add_argument('--path', type=str, default='~/bin/maritalk', help='Path for the executable.')
-    parser.add_argument('--cuda', type=int, choices=[11, 12], default=None, help='Installed CUDA version.')
-    parser.add_argument('--port', type=int, default=9000, help='The HTTP port to bind.')
+    parser.add_argument(
+        "--license",
+        type=str,
+        required=True,
+        help="License key for downloading the model.",
+    )
+    parser.add_argument(
+        "--path", type=str, default="~/bin/maritalk", help="Path for the executable."
+    )
+    parser.add_argument(
+        "--cuda",
+        type=int,
+        choices=[11, 12],
+        default=None,
+        help="Installed CUDA version.",
+    )
+    parser.add_argument("--port", type=int, default=9000, help="The HTTP port to bind.")
     args = parser.parse_args()
 
     process = start_server(args.license, args.path, args.cuda, args.port)
@@ -15,7 +28,7 @@ if __name__ == '__main__':
 
     while True:
         output = process.stdout.readline()
-        if process.poll() is not None and output == b'':
+        if process.poll() is not None and output == b"":
             break
         if output:
             print(output.decode().strip())


### PR DESCRIPTION
This PR adds 2 commands to this package:

```console
$ python -m maritalk.download --license <LICENSE> --path maritalk-small
```

```console
$ python -m maritalk.start --license <LICENSE>
```

They're useful for helping the user manage the executable and not depending on a Python console. They're also intended to use in a Docker documentation I'm working on.