### PR TITLE
Add the max_tokens parameter

### DIFF
--- a/documentation/docs/pt/maritalk-api/comeco-rapido.md
+++ b/documentation/docs/pt/maritalk-api/comeco-rapido.md
@@ -211,7 +211,7 @@ model = maritalk.MariTalk(
     model="sabia-3"  # No momento, suportamos os modelos sabia-3, sabia-2-medium e sabia-2-small
 )
 
-response = model.generate("Quanto é 25 + 27?")
+response = model.generate("Quanto é 25 + 27?", max_tokens=200)
 answer = response["answer"]
 
 print(f"Resposta: {answer}")   # Deve imprimir algo como "25 + 27 é igual a 52."


### PR DESCRIPTION
By adding the max_tokens parameters, users will know how to use it and avoid confusions when the answer is truncated.