### PR TITLE
Change "free tier" to "tier 0"

### DIFF
--- a/documentation/docs/en/models.md
+++ b/documentation/docs/en/models.md
@@ -24,8 +24,6 @@ RPM = Requests per minute.
 
 This table excludes all of our deprecated models.
 
-**The sabia-3-2024-09-09 model will be deprecated on 2025-02-15. We recommended changing to sabia-3.**
-
 ## Deprecated Models
 
 As we release more advanced and secure models, we regularly discontinue older models. In the table below, you will find a complete list of deprecated models, along with recommended replacements.

--- a/documentation/docs/en/rate-limits.md
+++ b/documentation/docs/en/rate-limits.md
@@ -38,16 +38,14 @@ As your API usage and spending increase, you are automatically promoted to the n
 
 |Tier|Required Spending|
 |---|---|
-|Free| 0 | 
+|Tier 0| 0 | 
 |Tier 1|Any API Spending|
 |Tier 2|R$100 |
 |Tier 3|R$500|
 |Tier 4|R$2,000|
 |Tier 5|R$5,000|
 
-Select a tier below to view a general summary of rate limits per model:
-
-### Free tier rate limits
+### Tier 0 rate limits
 
 |Model|RPM|TPM Input|TPM Output|
 |---|---|---|---|

--- a/documentation/docs/pt/modelos.md
+++ b/documentation/docs/pt/modelos.md
@@ -25,7 +25,6 @@ TPM = Tokens por minuto.
 RPM = Requisições por minuto.
 
 
-
 ## Modelos descontinuados
 
 Conforme lançamos modelos mais seguros e avançados, descontinuamos regularmente os modelos antigos. Na tabela abaixo, você encontrará uma lista completa de modelos descontinuados, além das recomendações de substituição.

--- a/documentation/docs/pt/rate-limits.md
+++ b/documentation/docs/pt/rate-limits.md
@@ -18,7 +18,7 @@ Os **Rate Limits** são mecanismos que controlam quantas requisições ou opera�
 ## Como funciona o Rate Limit?
 
 **Limite por usuário (user-level rate limit)**  
-Estabelece quantas requisições cada usuário ou api_key pode fazer dentro de um período específico. Os limites de taxa são medidos de duas maneiras:
+Estabelece quantas requisições cada usuário ou api_key pode fazer dentro de um período específico. Os rate limits são medidos de duas maneiras:
 
 * RPM (Requisições por minuto)
 * TPM (Tokens por minuto)
@@ -33,21 +33,19 @@ Observação:
 
 ## Níveis de uso
 
-Conforme o uso e o gasto na API aumentam, você é automaticamente promovido para o próximo nível. Cada nível oferece limites de taxa mais altos para os modelos.
+Conforme o uso e o gasto na API aumentam, você é automaticamente promovido para o próximo nível. Cada nível oferece rate limits mais altos para os modelos.
 **Observação:** Créditos iniciais e cupons não contam para subir de tier, apenas os gastos na API.
 
 |Tier|Gasto requerido|
 |---|---|
-|Free| 0 | 
+|Tier 0| 0 | 
 |Tier 1|Qualquer gasto com a API|
 |Tier 2|R$100 |
 |Tier 3|R$500|
 |Tier 4|R$2.000|
 |Tier 5|R$5.000|
 
-Selecione um nível abaixo para conferir o resumo geral dos limites de taxa por modelo:
-
-### Free tier rate limits
+### Tier 0 rate limits
 
 |Model|RPM|TPM Input|TPM Output|
 |---|---|---|---|


### PR DESCRIPTION
Also remove left-over of deprecated model.
Also standardize the use of "rate limit", as opposed to "limites de taxa", in the portuguese documentation.