### PR TITLE
docs: fix Batch API window and cached tokens stacking

### DIFF
--- a/documentation/docs/en/flex-tier.md
+++ b/documentation/docs/en/flex-tier.md
@@ -40,8 +40,8 @@ Flex requests have the same 50% discount as the Batch API, but are processed in 
 | | **Flex** | **Batch API** |
 |---|---|---|
 | **Discount** | 50% | 50% |
-| **Response** | Real-time (synchronous) | Up to 24h (asynchronous) |
-| **Availability** | Subject to capacity (may return 429) | Guaranteed within 24h window |
+| **Response** | Real-time (synchronous) | Up to 7 days (asynchronous) |
+| **Availability** | Subject to capacity (may return 429) | No delivery guarantee (requests may expire) |
 | **Streaming** | Yes | No |
 | **Best for** | Applications that tolerate retry | Non-urgent batch processing |
 
@@ -49,7 +49,7 @@ Flex requests have the same 50% discount as the Batch API, but are processed in 
 
 1. **Implement retry with backoff**: since Flex requests may return 429, add retry logic with exponential backoff.
 2. **Ideal for multi-agent architectures**: agents can send discounted requests and simply retry if they receive 429.
-3. **Combine with prompt caching**: cached tokens keep the 75% discount on input price, stacking with the Flex discount for even greater savings.
+3. **Combine with prompt caching**: cached tokens have a 75% discount on input price, but this discount does not stack with the Flex discount.
 
 <style>
   {`

--- a/documentation/docs/en/prompt-caching.md
+++ b/documentation/docs/en/prompt-caching.md
@@ -52,7 +52,6 @@ Cached tokens pay 25% of the standard input price. See the full pricing table on
 
 1. **Place stable content at the beginning of the prompt**: system prompts and reference documents should come before dynamic content (e.g., the user's question).
 2. **Reuse identical prefixes**: the larger the common prefix between requests, the greater the savings.
-3. **Combine with other strategies**: caching stacks with off-peak, Flex, and Batch API discounts to maximize savings.
 
 <style>
   {`

--- a/documentation/docs/pt/cache-de-prompt.md
+++ b/documentation/docs/pt/cache-de-prompt.md
@@ -52,7 +52,6 @@ Tokens cacheados pagam 25% do preço de input padrão. Consulte a tabela complet
 
 1. **Coloque o conteúdo estável no início do prompt**: system prompts e documentos de referência devem vir antes do conteúdo dinâmico (ex.: a pergunta do usuário).
 2. **Reutilize prefixos idênticos**: quanto maior o prefixo comum entre requisições, maior a economia.
-3. **Combine com outras estratégias**: o cache se acumula com descontos de horário noturno, Flex e Batch API para maximizar a economia.
 
 <style>
   {`

--- a/documentation/docs/pt/flex-tier.md
+++ b/documentation/docs/pt/flex-tier.md
@@ -40,8 +40,8 @@ Requisições Flex têm o mesmo desconto de 50% da Batch API, mas são processad
 | | **Flex** | **Batch API** |
 |---|---|---|
 | **Desconto** | 50% | 50% |
-| **Resposta** | Tempo real (síncrona) | Até 24h (assíncrona) |
-| **Disponibilidade** | Sujeita a capacidade (pode retornar 429) | Garantida dentro da janela de 24h |
+| **Resposta** | Tempo real (síncrona) | Até 7 dias (assíncrona) |
+| **Disponibilidade** | Sujeita a capacidade (pode retornar 429) | Sem garantia de entrega (requisições podem expirar) |
 | **Streaming** | Sim | Não |
 | **Ideal para** | Aplicações que toleram retry | Processamento em lote sem urgência |
 
@@ -49,7 +49,7 @@ Requisições Flex têm o mesmo desconto de 50% da Batch API, mas são processad
 
 1. **Implemente retry com backoff**: como requisições Flex podem retornar 429, adicione lógica de retry com backoff exponencial.
 2. **Ideal para arquiteturas multiagente**: agentes podem enviar requisições com desconto e simplesmente tentar novamente se receberem 429.
-3. **Combine com cache de prompt**: tokens cacheados mantêm o desconto de 75% sobre o preço de input, acumulando com o desconto Flex para economia ainda maior.
+3. **Combine com cache de prompt**: tokens cacheados têm desconto de 75% sobre o preço de input, mas esse desconto não acumula com o desconto Flex.
 
 <style>
   {`


### PR DESCRIPTION
## Summary
- **Batch API**: janela de conclusão corrigida de 24h para 7 dias, sem garantia de entrega
- **Flex Tier (Boas Práticas)**: desconto de cached tokens não acumula com desconto Flex
- **Cache de Prompt / Prompt Caching**: removido item "Combine com outras estratégias" que afirmava incorretamente que descontos acumulam

## Test plan
- [ ] Verificar página Flex Tier (PT e EN) — tabela e boas práticas
- [ ] Verificar página Cache de Prompt (PT e EN) — seção de dicas

🤖 Generated with [Claude Code](https://claude.com/claude-code)