### PR TITLE
docs: rename Files page to Documentos e PDFs + OCR mentions

### DIFF
--- a/documentation/docs/en/files_in_completions_api_en.md
+++ b/documentation/docs/en/files_in_completions_api_en.md
@@ -1,9 +1,11 @@
 ---
 id: files
-title: File Inputs
+title: Document & PDF Processing
+sidebar_label: Documents & PDFs
 ---
 
-Our API supports uploading files directly through the Chat Completions endpoint.
+Our API supports sending documents directly through the Chat Completions endpoint.
+The API extracts textual content from files — including **OCR for PDFs** with images, tables, and complex layouts — and feeds it to the model.
 At the moment, files must be sent **in Base64 format**.
 
 Below is an example illustrating how to upload a PDF to the API:
@@ -46,8 +48,7 @@ response = client.chat.completions.create(
 )
 ```
 
-When you submit files, the API extracts the text content and feeds it to the model.
-All extracted content is returned in the response and can be accessed like this:
+Extracted content is returned in the response and can be accessed like this:
 
 ```python
 extracted_docs = response.extracted_files
@@ -80,8 +81,8 @@ If not specified, the default extraction level is **`medium`**.
 
 | Level      | Description                                                            | Cost per page of PDF   |
 | ---------- | ---------------------------------------------------------------------- | ---------------------- |
-| `medium`   | Balanced extraction. Works best for most PDFs.                         | R$ 0,02                |
-| `advanced` | Highest-quality extraction for complex layouts, formulas, or diagrams. | R$ 0,045               |
+| `medium`   | Balanced OCR extraction. Works best for most PDFs.                              | R$ 0,02                |
+| `advanced` | Advanced OCR; highest quality for complex layouts, formulas, tables, or images. | R$ 0,045               |
 
 You can check the extraction pricing on our [platform](https://plataforma.maritaca.ai/modelos).
 

--- a/documentation/docs/pt/files_in_completions_api_pt.md
+++ b/documentation/docs/pt/files_in_completions_api_pt.md
@@ -1,9 +1,11 @@
 ---
 id: files
-title: Upload de Arquivos
+title: Processamento de Documentos e PDFs
+sidebar_label: Documentos e PDFs
 ---
 
-Nossa API permite o envio de arquivos diretamente pelo endpoint de Chat Completions.
+Nossa API permite o envio de documentos diretamente pelo endpoint de Chat Completions.
+A API extrai o conteúdo textual dos arquivos — incluindo **OCR para PDFs** com imagens, tabelas e layouts complexos — e o repassa ao modelo.
 Atualmente, os arquivos devem ser enviados **em formato Base64**.
 
 Abaixo está um exemplo de como enviar um PDF para a API:
@@ -46,8 +48,7 @@ response = client.chat.completions.create(
 )
 ```
 
-Quando arquivos são enviados, a API extrai o conteúdo textual e o repassa ao modelo.
-Todo o conteúdo extraído é retornado na resposta e pode ser acessado assim:
+O conteúdo extraído é retornado na resposta e pode ser acessado assim:
 
 ```python
 extracted_docs = response.extracted_files
@@ -80,8 +81,8 @@ Se não for especificado, o nível padrão é **`medium`**.
 
 | Nível      | Descrição                                                     | Custo por página do PDF  |
 | ---------- | ------------------------------------------------------------- | ------------------------ |
-| `medium`   | Extração intermediária; ideal para a maioria dos PDFs.        | R$ 0,02                  |
-| `advanced` | Extração avançada; melhor para PDFs complexos e com fórmulas. | R$ 0,045                 |
+| `medium`   | Extração intermediária com OCR; ideal para a maioria dos PDFs.              | R$ 0,02                  |
+| `advanced` | OCR avançado; melhor para PDFs complexos, com fórmulas, tabelas e imagens.  | R$ 0,045                 |
 
 Você pode consultar os preços de extração na nossa [plataforma](https://plataforma.maritaca.ai/modelos).
 


### PR DESCRIPTION
## Summary
- Renomeia "Upload de Arquivos" → "Documentos e PDFs" (sidebar) / "Processamento de Documentos e PDFs" (título)
- EN: "File Inputs" → "Documents & PDFs" / "Document & PDF Processing"
- Adiciona menções a OCR na intro e na tabela de extraction effort
- Remove frase redundante sobre extração (já coberta pela nova intro)

## Why
O título anterior sugeria um endpoint de upload separado, mas os arquivos são enviados inline (Base64) no Chat Completions. "OCR" é um termo comumente buscado e descreve melhor a capacidade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)