### PR TITLE
docs: add image support (image_url + type:file)

### DIFF
--- a/documentation/docs/en/files_in_completions_api_en.md
+++ b/documentation/docs/en/files_in_completions_api_en.md
@@ -67,6 +67,71 @@ We currently support the following file types:
 * **XML**
 * **XLSX**
 * **MD**
+* **PNG / JPEG** (images)
+
+---
+
+## Images
+
+The API also accepts images (PNG and JPEG) using the OpenAI-compatible `image_url` format.
+Image content is extracted via OCR and passed to the model as text.
+
+You can send an image via URL or Base64:
+
+```python
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "https://example.com/photo.png",
+                },
+            },
+            {
+                "type": "text",
+                "text": "What does this image say?",
+            },
+        ],
+    }
+]
+
+response = client.chat.completions.create(
+    model="sabia-4",
+    messages=messages,
+)
+```
+
+To send the image as Base64 (no public URL needed):
+
+```python
+with open("photo.png", "rb") as f:
+    img_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/png;base64,{img_b64}",
+                },
+            },
+            {
+                "type": "text",
+                "text": "Extract the text from this image.",
+            },
+        ],
+    }
+]
+```
+
+:::info
+Images are processed via OCR — the model receives extracted text, not the original image.
+Supported formats: **PNG** and **JPEG**.
+:::
 
 ---
 
@@ -81,8 +146,8 @@ If not specified, the default extraction level is **`medium`**.
 
 | Level      | Description                                                            | Cost per page of PDF   |
 | ---------- | ---------------------------------------------------------------------- | ---------------------- |
-| `medium`   | Balanced OCR extraction. Works best for most PDFs.                              | R$ 0,02                |
-| `advanced` | Advanced OCR; highest quality for complex layouts, formulas, tables, or images. | R$ 0,045               |
+| `medium`   | OCR for text, tables, and images; works best for most PDFs.    | R$ 0,02                |
+| `advanced` | Same coverage as medium + formulas and complex layouts.         | R$ 0,045               |
 
 You can check the extraction pricing on our [platform](https://plataforma.maritaca.ai/modelos).
 

--- a/documentation/docs/en/files_in_completions_api_en.md
+++ b/documentation/docs/en/files_in_completions_api_en.md
@@ -128,6 +128,32 @@ messages = [
 ]
 ```
 
+Images can also be sent as `type: "file"`, just like PDFs and other documents:
+
+```python
+with open("photo.png", "rb") as f:
+    img_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "file",
+                "file": {
+                    "filename": "photo.png",
+                    "file_data": f"data:image/png;base64,{img_b64}",
+                },
+            },
+            {
+                "type": "text",
+                "text": "Extract the text from this image.",
+            },
+        ],
+    }
+]
+```
+
 :::info
 Images are processed via OCR — the model receives extracted text, not the original image.
 Supported formats: **PNG** and **JPEG**.

--- a/documentation/docs/pt/files_in_completions_api_pt.md
+++ b/documentation/docs/pt/files_in_completions_api_pt.md
@@ -67,6 +67,71 @@ Atualmente, suportamos os seguintes tipos de arquivo:
 * **XML**
 * **XLSX**
 * **MD**
+* **PNG / JPEG** (imagens)
+
+---
+
+## Imagens
+
+A API também aceita imagens (PNG e JPEG) no formato compatível com a OpenAI, usando `image_url`.
+O conteúdo da imagem é extraído via OCR e repassado ao modelo como texto.
+
+Você pode enviar uma imagem via URL ou em Base64:
+
+```python
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "https://example.com/foto.png",
+                },
+            },
+            {
+                "type": "text",
+                "text": "O que está escrito nesta imagem?",
+            },
+        ],
+    }
+]
+
+response = client.chat.completions.create(
+    model="sabia-4",
+    messages=messages,
+)
+```
+
+Para enviar a imagem em Base64 (sem precisar de URL pública):
+
+```python
+with open("foto.png", "rb") as f:
+    img_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/png;base64,{img_b64}",
+                },
+            },
+            {
+                "type": "text",
+                "text": "Extraia o texto desta imagem.",
+            },
+        ],
+    }
+]
+```
+
+:::info
+Imagens são processadas via OCR — o modelo recebe o texto extraído, não a imagem original. 
+Formatos suportados: **PNG** e **JPEG**.
+:::
 
 ---
 
@@ -81,8 +146,8 @@ Se não for especificado, o nível padrão é **`medium`**.
 
 | Nível      | Descrição                                                     | Custo por página do PDF  |
 | ---------- | ------------------------------------------------------------- | ------------------------ |
-| `medium`   | Extração intermediária com OCR; ideal para a maioria dos PDFs.              | R$ 0,02                  |
-| `advanced` | OCR avançado; melhor para PDFs complexos, com fórmulas, tabelas e imagens.  | R$ 0,045                 |
+| `medium`   | OCR para texto, tabelas e imagens; ideal para a maioria dos PDFs.  | R$ 0,02                  |
+| `advanced` | Mesma cobertura do medium + fórmulas e layouts complexos.          | R$ 0,045                 |
 
 Você pode consultar os preços de extração na nossa [plataforma](https://plataforma.maritaca.ai/modelos).
 

--- a/documentation/docs/pt/files_in_completions_api_pt.md
+++ b/documentation/docs/pt/files_in_completions_api_pt.md
@@ -128,8 +128,34 @@ messages = [
 ]
 ```
 
+Imagens também podem ser enviadas como `type: "file"`, da mesma forma que PDFs e outros documentos:
+
+```python
+with open("foto.png", "rb") as f:
+    img_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "file",
+                "file": {
+                    "filename": "foto.png",
+                    "file_data": f"data:image/png;base64,{img_b64}",
+                },
+            },
+            {
+                "type": "text",
+                "text": "Extraia o texto desta imagem.",
+            },
+        ],
+    }
+]
+```
+
 :::info
-Imagens são processadas via OCR — o modelo recebe o texto extraído, não a imagem original. 
+Imagens são processadas via OCR — o modelo recebe o texto extraído, não a imagem original.
 Formatos suportados: **PNG** e **JPEG**.
 :::
 


### PR DESCRIPTION
## Summary
- Adds "Imagens" section to the docs page (PT and EN) with 3 ways to send images:
  1. `image_url` with HTTP URL (new)
  2. `image_url` with base64 data URL (new)
  3. `type: "file"` with base64 (already worked)
- Clarifies extraction levels: medium also handles tables and images, advanced adds formulas
- Adds PNG/JPEG to the supported file types list

Companion to maritaca-ai/maritalk#585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)