### PR TITLE
docs: clarify Flex Tier queue timeout (up to 5 min before 429)

### DIFF
--- a/documentation/docs/en/flex-tier.md
+++ b/documentation/docs/en/flex-tier.md
@@ -5,7 +5,7 @@ title: Flex Tier
 
 # Flex Tier
 
-The Flex Tier offers a **50% discount** on synchronous (real-time) requests, subject to capacity availability. When capacity is unavailable, the API returns HTTP status code `429`.
+The Flex Tier offers a **50% discount** on synchronous (real-time) requests, subject to capacity availability. When capacity is not immediately available, the request waits in the queue for **up to 5 minutes**. If it is still not processed within that window, the API returns HTTP status code `429`.
 
 ## How to use
 
@@ -41,7 +41,7 @@ Flex requests have the same 50% discount as the Batch API, but are processed in 
 |---|---|---|
 | **Discount** | 50% | 50% |
 | **Response** | Real-time (synchronous) | Up to 24h (asynchronous) |
-| **Availability** | Subject to capacity (may return 429) | Guaranteed within 24h window |
+| **Availability** | Subject to capacity (queued up to 5 min, then 429) | Guaranteed within 24h window |
 | **Streaming** | Yes | No |
 | **Best for** | Applications that tolerate retry | Non-urgent batch processing |
 

--- a/documentation/docs/en/flex-tier.md
+++ b/documentation/docs/en/flex-tier.md
@@ -5,7 +5,7 @@ title: Flex Tier
 
 # Flex Tier
 
-The Flex Tier offers a **50% discount** on synchronous (real-time) requests, subject to capacity availability. When capacity is not immediately available, the request waits in the queue for **up to 5 minutes**. If it is still not processed within that window, the API returns HTTP status code `429`.
+The Flex Tier offers a **50% discount** on synchronous (real-time) requests, subject to capacity availability. When capacity is not immediately available, the request is queued and waits for **up to 5 minutes** before the API returns HTTP status code `429`. If the queue is already full when the request arrives, the API returns `429` immediately.
 
 ## How to use
 
@@ -41,7 +41,7 @@ Flex requests have the same 50% discount as the Batch API, but are processed in 
 |---|---|---|
 | **Discount** | 50% | 50% |
 | **Response** | Real-time (synchronous) | Up to 24h (asynchronous) |
-| **Availability** | Subject to capacity (queued up to 5 min, then 429) | Guaranteed within 24h window |
+| **Availability** | Subject to capacity (queue up to 5 min, or immediate 429 if queue is full) | Guaranteed within 24h window |
 | **Streaming** | Yes | No |
 | **Best for** | Applications that tolerate retry | Non-urgent batch processing |
 

--- a/documentation/docs/pt/flex-tier.md
+++ b/documentation/docs/pt/flex-tier.md
@@ -5,7 +5,7 @@ title: Flex Tier
 
 # Flex Tier
 
-O Flex Tier oferece **50% de desconto** em requisições síncronas (tempo real), sujeitas a disponibilidade de capacidade. Quando não há capacidade disponível, a API retorna o código HTTP `429`.
+O Flex Tier oferece **50% de desconto** em requisições síncronas (tempo real), sujeitas a disponibilidade de capacidade. Quando não há capacidade disponível imediata, a requisição fica na fila por **até 5 minutos**. Se ainda assim não for processada nesse período, a API retorna o código HTTP `429`.
 
 ## Como usar
 
@@ -41,7 +41,7 @@ Requisições Flex têm o mesmo desconto de 50% da Batch API, mas são processad
 |---|---|---|
 | **Desconto** | 50% | 50% |
 | **Resposta** | Tempo real (síncrona) | Até 24h (assíncrona) |
-| **Disponibilidade** | Sujeita a capacidade (pode retornar 429) | Garantida dentro da janela de 24h |
+| **Disponibilidade** | Sujeita a capacidade (fica na fila até 5 min, depois 429) | Garantida dentro da janela de 24h |
 | **Streaming** | Sim | Não |
 | **Ideal para** | Aplicações que toleram retry | Processamento em lote sem urgência |
 

--- a/documentation/docs/pt/flex-tier.md
+++ b/documentation/docs/pt/flex-tier.md
@@ -5,7 +5,7 @@ title: Flex Tier
 
 # Flex Tier
 
-O Flex Tier oferece **50% de desconto** em requisições síncronas (tempo real), sujeitas a disponibilidade de capacidade. Quando não há capacidade disponível imediata, a requisição fica na fila por **até 5 minutos**. Se ainda assim não for processada nesse período, a API retorna o código HTTP `429`.
+O Flex Tier oferece **50% de desconto** em requisições síncronas (tempo real), sujeitas a disponibilidade de capacidade. Quando não há capacidade disponível imediata, a requisição entra em uma fila e aguarda por **até 5 minutos** antes de retornar o código HTTP `429`. Se a fila estiver cheia no momento da requisição, a API retorna `429` imediatamente.
 
 ## Como usar
 
@@ -41,7 +41,7 @@ Requisições Flex têm o mesmo desconto de 50% da Batch API, mas são processad
 |---|---|---|
 | **Desconto** | 50% | 50% |
 | **Resposta** | Tempo real (síncrona) | Até 24h (assíncrona) |
-| **Disponibilidade** | Sujeita a capacidade (fica na fila até 5 min, depois 429) | Garantida dentro da janela de 24h |
+| **Disponibilidade** | Sujeita a capacidade (fila de até 5 min, ou 429 imediato se fila cheia) | Garantida dentro da janela de 24h |
 | **Streaming** | Sim | Não |
 | **Ideal para** | Aplicações que toleram retry | Processamento em lote sem urgência |
 


### PR DESCRIPTION
## Summary
Per @thiagolaitz on LinkedIn: Flex Tier requests don't return 429 immediately when capacity is unavailable — they wait in the queue for **up to 5 minutes** before returning 429.

## Changes
- Intro paragraph: clarifies the 5-minute queue wait before 429
- Flex vs Batch API table: updates the Availability row to reflect queuing behavior

Both PT and EN versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)