### PR TITLE
fix(docs): Flex and cache discounts are not cumulative

### DIFF
--- a/documentation/docs/en/flex-tier.md
+++ b/documentation/docs/en/flex-tier.md
@@ -47,7 +47,7 @@ Flex requests have the same 50% discount as the Batch API, but are processed in 
 
 ## Best practices
 
-1. **Combine with prompt caching**: cached tokens keep the 75% discount on input price, stacking with the Flex discount for even greater savings.
+1. **Combine with prompt caching**: cached tokens keep the 75% discount on input price. Note that the cache and Flex discounts are **not cumulative** — each applies independently to its respective component.
 2. **Implement retry with backoff**: since Flex requests may return 429, add retry logic with exponential backoff.
 
 ```python

--- a/documentation/docs/pt/flex-tier.md
+++ b/documentation/docs/pt/flex-tier.md
@@ -47,7 +47,7 @@ Requisições Flex têm o mesmo desconto de 50% da Batch API, mas são processad
 
 ## Boas práticas
 
-1. **Combine com cache de prompt**: tokens cacheados mantêm o desconto de 75% sobre o preço de input, acumulando com o desconto Flex para economia ainda maior.
+1. **Combine com cache de prompt**: tokens cacheados mantêm o desconto de 75% sobre o preço de input. Os descontos de cache e Flex **não são cumulativos** — cada um se aplica independentemente ao seu respectivo componente.
 2. **Implemente retry com backoff**: como requisições Flex podem retornar 429, adicione lógica de retry com backoff exponencial.
 
 ```python


### PR DESCRIPTION
## Summary
- Corrige a documentação do Flex Tier (PT e EN) que dizia que os descontos de cache (75%) e Flex (50%) eram cumulativos — não são.
- Endereça o comentário do @thiagolaitz na PR #207.

## Test plan
- [ ] Verificar a página Flex Tier em PT e EN

🤖 Generated with [Claude Code](https://claude.com/claude-code)