### PR TITLE
fix(docs): corrigir informação sobre acúmulo de descontos no cache

### DIFF
--- a/documentation/docs/en/flex-tier.md
+++ b/documentation/docs/en/flex-tier.md
@@ -47,7 +47,7 @@ Flex requests have the same 50% discount as the Batch API, but are processed in 
 
 ## Best practices
 
-1. **Combine with prompt caching**: cached tokens keep the 75% discount on input price. Note that the cache and Flex discounts are **not cumulative** — each applies independently to its respective component.
+1. **Combine with prompt caching**: cached tokens keep the 75% discount on input price. The Flex discount (50%) applies only to non-cached input tokens and output tokens — the discounts do not multiply. See more details at [Prompt Caching](prompt-caching#how-discounts-interact).
 2. **Implement retry with backoff**: since Flex requests may return 429, add retry logic with exponential backoff.
 
 ```python

--- a/documentation/docs/en/precos.md
+++ b/documentation/docs/en/precos.md
@@ -25,6 +25,10 @@ All prices are per million tokens processed. Billing considers both input and ou
 
 <small>³ Flex requests offer a 50% discount, subject to capacity availability. Learn more at [Flex Tier](flex-tier).</small>
 
+:::info How discounts interact
+The cache discount (75%) applies only to cached input tokens. Batch API, Flex, and off-peak discounts apply only to non-cached input tokens and output tokens — they do not multiply with the cache discount. Additionally, Batch API, Flex, and off-peak are mutually exclusive. See more details at [Prompt Caching](prompt-caching#how-discounts-interact).
+:::
+
 ## How do I know how many tokens I will be charged?
 
 To know in advance how much your requests will cost, use the `count_tokens` function to find out the number of tokens in a given prompt.

--- a/documentation/docs/en/prompt-caching.md
+++ b/documentation/docs/en/prompt-caching.md
@@ -52,7 +52,22 @@ Cached tokens pay 25% of the standard input price. See the full pricing table on
 
 1. **Place stable content at the beginning of the prompt**: system prompts and reference documents should come before dynamic content (e.g., the user's question).
 2. **Reuse identical prefixes**: the larger the common prefix between requests, the greater the savings.
-3. **Combine with other strategies**: caching stacks with off-peak, Flex, and Batch API discounts to maximize savings.
+3. **Combine with other strategies**: the cache discount can be used alongside off-peak, Flex, and Batch API discounts — each one applies to a different part of the cost (see below).
+
+## How discounts interact
+
+The cache discount (75%) applies only to cached input tokens. Other discounts (Batch API, Flex, off-peak) apply only to non-cached input tokens and output tokens. Discounts do not multiply with each other.
+
+Batch API, Flex, and off-peak are mutually exclusive — only one of them is applied per request.
+
+| Scenario | Non-cached input and output | Cached tokens |
+|---|---|---|
+| Batch + cache | 50% discount | 75% discount |
+| Flex + cache | 50% discount | 75% discount |
+| Off-peak + cache | 30% discount | 75% discount |
+| Off-peak + Flex | Flex only (50%) | — |
+| Off-peak + Batch | Batch only (50%) | — |
+| Cache only | no discount | 75% discount |
 
 <style>
   {`

--- a/documentation/docs/pt/cache-de-prompt.md
+++ b/documentation/docs/pt/cache-de-prompt.md
@@ -52,7 +52,22 @@ Tokens cacheados pagam 25% do preço de input padrão. Consulte a tabela complet
 
 1. **Coloque o conteúdo estável no início do prompt**: system prompts e documentos de referência devem vir antes do conteúdo dinâmico (ex.: a pergunta do usuário).
 2. **Reutilize prefixos idênticos**: quanto maior o prefixo comum entre requisições, maior a economia.
-3. **Combine com outras estratégias**: o cache se acumula com descontos de horário noturno, Flex e Batch API para maximizar a economia.
+3. **Combine com outras estratégias**: o desconto de cache pode ser usado junto com descontos de horário noturno, Flex e Batch API — cada um incide sobre uma parte diferente do custo (veja abaixo).
+
+## Como os descontos interagem
+
+O desconto de cache (75%) se aplica apenas aos tokens de input em cache. Os demais descontos (Batch API, Flex, horário noturno) se aplicam apenas aos tokens de input não cacheados e aos tokens de output. Os descontos não se multiplicam entre si.
+
+Batch API, Flex e horário noturno são mutuamente exclusivos — apenas um deles é aplicado por requisição.
+
+| Cenário | Input não cacheado e output | Tokens em cache |
+|---|---|---|
+| Batch + cache | 50% de desconto | 75% de desconto |
+| Flex + cache | 50% de desconto | 75% de desconto |
+| Horário noturno + cache | 30% de desconto | 75% de desconto |
+| Horário noturno + Flex | só Flex (50%) | — |
+| Horário noturno + Batch | só Batch (50%) | — |
+| Somente cache | sem desconto | 75% de desconto |
 
 <style>
   {`

--- a/documentation/docs/pt/flex-tier.md
+++ b/documentation/docs/pt/flex-tier.md
@@ -47,7 +47,7 @@ Requisições Flex têm o mesmo desconto de 50% da Batch API, mas são processad
 
 ## Boas práticas
 
-1. **Combine com cache de prompt**: tokens cacheados mantêm o desconto de 75% sobre o preço de input. Os descontos de cache e Flex **não são cumulativos** — cada um se aplica independentemente ao seu respectivo componente.
+1. **Combine com cache de prompt**: tokens em cache mantêm o desconto de 75% sobre o preço de input. O desconto Flex (50%) se aplica apenas aos tokens de input não cacheados e de output — os descontos não se multiplicam. Veja mais detalhes em [Cache de Prompt](cache-de-prompt#como-os-descontos-interagem).
 2. **Implemente retry com backoff**: como requisições Flex podem retornar 429, adicione lógica de retry com backoff exponencial.
 
 ```python

--- a/documentation/docs/pt/precos.md
+++ b/documentation/docs/pt/precos.md
@@ -25,6 +25,10 @@ Todos os preços são por milhão de tokens processados. A cobrança considera t
 
 <small>³ Requisições Flex oferecem 50% de desconto, sujeitas a disponibilidade de capacidade. Saiba mais em [Flex Tier](flex-tier).</small>
 
+:::info Como os descontos interagem
+O desconto de cache (75%) se aplica apenas aos tokens de input em cache. Os descontos de Batch API, Flex e horário noturno se aplicam apenas aos tokens de input não cacheados e de output — eles não se multiplicam com o desconto de cache. Além disso, Batch API, Flex e horário noturno são mutuamente exclusivos. Veja mais detalhes em [Cache de Prompt](cache-de-prompt#como-os-descontos-interagem).
+:::
+
 ## Como saber quantos tokens serei cobrado?
 
 Para saber de antemão o quanto suas requisições irão custar, use a função `count_tokens` para saber o número de tokens em um dado prompt.


### PR DESCRIPTION
## Summary
- Corrige texto que afirmava que o desconto de cache "se acumula" / "stacks" com outros descontos (sugerindo composição multiplicativa)
- Adiciona seção "Como os descontos interagem" / "How discounts interact" nas páginas de cache (PT/EN) com tabela detalhada
- Adiciona callout nas páginas de preços (PT/EN) esclarecendo a interação e linkando para a tabela
- Melhora texto nas páginas do Flex Tier (PT/EN) para ser mais explícito sobre quais componentes cada desconto afeta

## Arquivos alterados
- `documentation/docs/pt/cache-de-prompt.md`
- `documentation/docs/en/prompt-caching.md`
- `documentation/docs/pt/precos.md`
- `documentation/docs/en/precos.md`
- `documentation/docs/pt/flex-tier.md`
- `documentation/docs/en/flex-tier.md`