### PR TITLE
docs: adiciona Sabiá 4 Thinking e remove Sabiá 3/3.1/Sabiazinho 3

### DIFF
--- a/documentation/docs/en/introduction.md
+++ b/documentation/docs/en/introduction.md
@@ -54,6 +54,136 @@ It is important to remember that, although the models are a powerful tool for la
 
 Thanks to our specialized training in Portuguese and Brazilian-specific contexts, our models achieve strong performance on national benchmarks at significantly lower cost than comparable alternatives. 
 
+### Sabiá 4 Thinking
+
+Sabiá 4 Thinking is the reasoning model of the Sabiá family: it reaches frontier quality in Portuguese and Brazilian contexts at the lowest cost among the evaluated models. Compared to Sabiá 4, it brings significant gains in tool use, legal tasks, and answer quality.
+
+The table below shows Sabiá 4 Thinking's performance, benchmark by benchmark, against the leading frontier models across three fronts: function calling and agents, legal, and general tasks. The competitors (Gemini 3.1 Pro, GPT-5.4, and Opus 4.8) were evaluated at *reasoning effort* medium. Running the full suite costs less than half of GPT-5.4 and about a third of Opus 4.8 on Sabiá 4 Thinking. In **bold**, the best in each row.
+
+<style>{`
+  .bench-thinking { margin: 1.75rem auto; border: 1px solid #e5e7eb; border-radius: 12px; background: #fff; overflow-x: auto; }
+  .bench-thinking table { width: 100%; table-layout: fixed; border-collapse: collapse; }
+  .bench-thinking caption { padding: 1rem 1.25rem; font-weight: 700; font-size: 0.95rem; text-align: center; color: #0f172a; }
+  .bench-thinking th, .bench-thinking td { padding: 0.6rem 0.5rem; border-bottom: 1px solid #e5e7eb; text-align: center; vertical-align: middle; font-size: 0.82rem; }
+  .bench-thinking thead th { background: #111827; color: #f8fafc; text-transform: uppercase; letter-spacing: 0.02em; font-size: 0.72rem; white-space: normal; line-height: 1.25; }
+  .bench-thinking thead th .eff { display: block; text-transform: none; font-weight: 400; font-size: 0.9em; opacity: 0.7; letter-spacing: 0; margin-top: 3px; }
+  .bench-thinking th:nth-child(1), .bench-thinking td:nth-child(1) { text-align: left; width: 32%; }
+  .bench-thinking th:nth-child(2), .bench-thinking td:nth-child(2) { background: #e8f9f1; color: #0f172a; font-weight: 600; }
+  .bench-thinking tbody tr:nth-child(odd) { background: #f9fafb; }
+  .bench-thinking td.grp { text-align: left; background: #fff; color: #ea580c; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; padding-top: 1rem; padding-bottom: 0.35rem; }
+  .bench-thinking .src { color: #94a3b8; font-weight: 400; }
+  [data-theme='dark'] .bench-thinking { border-color: #262626; background: #0f1115; }
+  [data-theme='dark'] .bench-thinking th, [data-theme='dark'] .bench-thinking td { border-color: #262626; color: #e5e7eb; }
+  [data-theme='dark'] .bench-thinking thead th { background: #1f2937; color: #f8fafc; }
+  [data-theme='dark'] .bench-thinking tbody tr:nth-child(odd) { background: #161922; }
+  [data-theme='dark'] .bench-thinking td:nth-child(2) { background: rgba(110,212,75,0.14); color: #e5e7eb; }
+  [data-theme='dark'] .bench-thinking td.grp { background: #0f1115; color: #fb923c; }
+`}</style>
+
+<div className="bench-thinking">
+  <table>
+    <caption>Sabiá 4 Thinking — performance by benchmark vs. frontier models</caption>
+    <thead>
+      <tr>
+        <th>Benchmark</th>
+        <th>Sabiá 4<br/>Thinking</th>
+        <th>Gemini 3.1 Pro<span className="eff">(effort medium)</span></th>
+        <th>GPT-5.4<span className="eff">(effort medium)</span></th>
+        <th>Opus 4.8<span className="eff">(effort medium)</span></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Total cost <span className="src">· R$ to run the suite</span></td>
+        <td><strong>R$ 206</strong></td>
+        <td>R$ 281</td>
+        <td>R$ 449</td>
+        <td>R$ 590</td>
+      </tr>
+      <tr><td className="grp" colSpan={5}>Function calling / Agents</td></tr>
+      <tr>
+        <td>Pix-Bench <span className="src">· internal</span></td>
+        <td><strong>100%</strong></td>
+        <td><strong>100%</strong></td>
+        <td><strong>100%</strong></td>
+        <td>97%</td>
+      </tr>
+      <tr>
+        <td>Ticket-Bench <span className="src">· public</span></td>
+        <td>98%</td>
+        <td><strong>100%</strong></td>
+        <td>98%</td>
+        <td>96.7%</td>
+      </tr>
+      <tr>
+        <td>MARCA <span className="src">· public</span></td>
+        <td>83.9%</td>
+        <td>84.8%</td>
+        <td><strong>93.2%</strong></td>
+        <td>91.5%</td>
+      </tr>
+      <tr><td className="grp" colSpan={5}>Legal</td></tr>
+      <tr>
+        <td>OAB (judge) <span className="src">· internal</span></td>
+        <td>90.1%</td>
+        <td>91.1%</td>
+        <td><strong>91.6%</strong></td>
+        <td>90.1%</td>
+      </tr>
+      <tr>
+        <td>Legal drafting <span className="src">· internal</span></td>
+        <td><strong>77.7%</strong></td>
+        <td>75.9%</td>
+        <td>72.8%</td>
+        <td>74.8%</td>
+      </tr>
+      <tr>
+        <td>Case extraction <span className="src">· internal</span></td>
+        <td>92.3%</td>
+        <td>91.4%</td>
+        <td><strong>95.7%</strong></td>
+        <td>94.3%</td>
+      </tr>
+      <tr><td className="grp" colSpan={5}>General</td></tr>
+      <tr>
+        <td>BLUEX <span className="src">· public</span></td>
+        <td>93%</td>
+        <td><strong>96.8%</strong></td>
+        <td>95.7%</td>
+        <td>95.4%</td>
+      </tr>
+      <tr>
+        <td>ENAMED <span className="src">· public</span></td>
+        <td>94.4%</td>
+        <td><strong>98.9%</strong></td>
+        <td>97.8%</td>
+        <td>97.8%</td>
+      </tr>
+      <tr>
+        <td>POSCOMP <span className="src">· public</span></td>
+        <td>90.8%</td>
+        <td>94.6%</td>
+        <td>94.6%</td>
+        <td><strong>96.2%</strong></td>
+      </tr>
+      <tr>
+        <td>PoETa v2 <span className="src">· public</span></td>
+        <td>83.7%</td>
+        <td>85%</td>
+        <td>83.3%</td>
+        <td><strong>86.3%</strong></td>
+      </tr>
+      <tr>
+        <td>Sotaques Digitais <span className="src">· public</span></td>
+        <td>94.6%</td>
+        <td>97.6%</td>
+        <td><strong>97.8%</strong></td>
+        <td><strong>97.8%</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
 ### Sabiá 4
 
 Read the [technical paper (arXiv)](https://arxiv.org/abs/2603.10213) for more details about Sabiá 4.
@@ -64,7 +194,22 @@ Sabiá 4 has higher accuracy on Brazilian Laws and consistent improvements over 
 
 This combination reinforces Sabiá 4 as a balanced choice for legal, educational, and institutional applications in Brazil that need local context and strong cost-performance.
 
-<div className="benchmark-table">
+<style>{`
+  .bench-thinking.wide table { table-layout: auto; min-width: 980px; }
+  .bench-thinking.wide thead th { white-space: nowrap; }
+  .bench-thinking.wide th:nth-child(2), .bench-thinking.wide td:nth-child(2) { display: none; }
+  .bench-thinking.wide th:nth-child(1), .bench-thinking.wide td:nth-child(1) { width: auto; }
+  .bench-thinking.wide th:nth-child(2), .bench-thinking.wide td:nth-child(2), .bench-thinking.wide th:nth-child(3), .bench-thinking.wide td:nth-child(3) { text-align: left; }
+  .bench-thinking.wide td:nth-child(2) { background: transparent; color: inherit; font-weight: 400; }
+  .bench-thinking.wide thead th:nth-child(2) { background: #111827; color: #f8fafc; }
+  .bench-thinking.wide th:nth-child(4), .bench-thinking.wide td:nth-child(4) { background: #e8f9f1; color: #0f172a; font-weight: 600; }
+  [data-theme='dark'] .bench-thinking.wide thead th:nth-child(2) { background: #1f2937; color: #f8fafc; }
+  [data-theme='dark'] .bench-thinking.wide thead th:nth-child(4) { background: #1f2937; color: #f8fafc; }
+  [data-theme='dark'] .bench-thinking.wide td:nth-child(2) { background: transparent; color: #e5e7eb; }
+  [data-theme='dark'] .bench-thinking.wide td:nth-child(4) { background: rgba(110,212,75,0.14); color: #e5e7eb; }
+`}</style>
+
+<div className="bench-thinking wide">
   <table>
     <caption>Comparison of performance and cost on Brazilian benchmarks</caption>
     <thead>

--- a/documentation/docs/en/models.md
+++ b/documentation/docs/en/models.md
@@ -9,6 +9,12 @@ Maritaca AI offers a range of models in the Sabiá family, designed to meet vari
 
 ## Available models
 
+### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4 Thinking</span></span>
+
+The reasoning model of the Sabiá family, delivering frontier quality in Portuguese and Brazilian contexts at the lowest cost among the evaluated models. Compared to Sabiá 4, it brings significant gains in tool use, legal tasks, and answer quality. Recommended for complex tasks that benefit from explicit reasoning before answering.
+
+**Example use cases:** Multi-step problem solving, agentic workflows and tool use, legal analysis and drafting, and exam questions and technical reasoning.
+
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4</span></span>
 
 General-purpose model focused on agentic capability and Brazilian context, updated through August 2024 and recommended for uses that need accuracy with cost efficiency. Read the [technical paper (arXiv)](https://arxiv.org/abs/2603.10213) for more details.
@@ -21,23 +27,13 @@ Optimized for large-scale applications with a focus on speed, low cost, and soli
 
 **Example use cases:** Drafting and reviewing legal documents, analyzing contracts, applying and interpreting Brazilian law, classifying and extracting information from documents, supporting large-scale educational assessments, and running agentic multi-step automations with fast responses and lower cost.
 
-### <span className="inline-title"><span className="geo-icon geo-icon-trophy geo-icon-small" aria-hidden="true"></span><span>Sabiá 3.1</span></span>
-
-Robust model updated through August 2024, with great performance in mathematical reasoning, code generation/refactoring, and tasks that require broad knowledge.
-
-**Example use cases:** Refactoring and optimizing legacy code across multiple languages, synthesizing clinical research reports, and serving as a legal assistant for complex contract reviews.
-
-### <span className="inline-title"><span className="geo-icon geo-icon-balance geo-icon-small" aria-hidden="true"></span><span>Sabiá 3</span></span> · <span className="inline-title"><span className="geo-icon geo-icon-bolt geo-icon-small" aria-hidden="true"></span><span>Sabiazinho 3</span></span>
-
-Previous generation models.
-
 ## Specifications
 
-| | **Sabiá 4** | **Sabiazinho 4** | **Sabiá 3.1** | **Sabiá 3** | **Sabiazinho 3** |
-|---|---|---|---|---|---|
-| **Max context** | 128K | 128K | 128K | 128K | 32K |
-| **Training data cutoff** | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 | Through mid-2023 | Through mid-2023 |
-| **Model names/aliases** | sabia-4<br />sabia-4-2026-01-06 | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabia-3.1<br />sabiá-3.1<br />sabia-3.1-2025-05-08<br />sabiá-3.1-2025-05-08 | sabia-3<br />sabiá-3<br />sabia-3-2024-12-11<br />sabiá-3-2024-12-11 | sabiazinho-3<br />sabiazinho-3-2025-02-06<br />sabia-3-small<br />sabiazim-3 |
+| | **Sabiá 4 Thinking** | **Sabiá 4** | **Sabiazinho 4** |
+|---|---|---|---|
+| **Max context** | 128K | 128K | 128K |
+| **Training data cutoff** | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 |
+| **Model names/aliases** | sabia-4-thinking | sabia-4<br />sabia-4-2026-01-06 | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 |
 
 For pricing information, see the [Pricing](precos) page.
 

--- a/documentation/docs/en/precos.md
+++ b/documentation/docs/en/precos.md
@@ -7,17 +7,17 @@ title: Pricing
 
 All prices are per million tokens processed. Billing considers both input and output tokens.
 
-| | **Sabiá 4** | **Sabiazinho 4** | **Sabiá 3.1** | **Sabiá 3** | **Sabiazinho 3** |
-|---|---|---|---|---|---|
-| **Input** | R$ 5.00 | R$ 1.00 | R$ 5.00 | R$ 5.00 | R$ 1.00 |
-| **Output** | R$ 20.00 | R$ 4.00 | R$ 10.00 | R$ 10.00 | R$ 3.00 |
-| **Cached input ¹** | R$ 1.25 | R$ 0.25 | R$ 1.25 | R$ 1.25 | R$ 0.25 |
-| **Off-peak input ²** | R$ 3.50 | R$ 0.70 | R$ 3.50 | R$ 3.50 | R$ 0.70 |
-| **Off-peak output ²** | R$ 14.00 | R$ 2.80 | R$ 7.00 | R$ 7.00 | R$ 2.10 |
-| **Flex input ³** | R$ 2.50 | R$ 0.50 | R$ 2.50 | R$ 2.50 | R$ 0.50 |
-| **Flex output ³** | R$ 10.00 | R$ 2.00 | R$ 5.00 | R$ 5.00 | R$ 1.50 |
-| **Batch API input** | R$ 2.50 | R$ 0.50 | R$ 2.50 | R$ 2.50 | R$ 0.50 |
-| **Batch API output** | R$ 10.00 | R$ 2.00 | R$ 5.00 | R$ 5.00 | R$ 1.50 |
+| | **Sabiá 4 Thinking** | **Sabiá 4** | **Sabiazinho 4** |
+|---|---|---|---|
+| **Input** | R$ 5.00 | R$ 5.00 | R$ 1.00 |
+| **Output** | R$ 40.00 | R$ 20.00 | R$ 4.00 |
+| **Cached input ¹** | R$ 1.25 | R$ 1.25 | R$ 0.25 |
+| **Off-peak input ²** | R$ 3.50 | R$ 3.50 | R$ 0.70 |
+| **Off-peak output ²** | R$ 28.00 | R$ 14.00 | R$ 2.80 |
+| **Flex input ³** | R$ 2.50 | R$ 2.50 | R$ 0.50 |
+| **Flex output ³** | R$ 20.00 | R$ 10.00 | R$ 2.00 |
+| **Batch API input** | R$ 2.50 | R$ 2.50 | R$ 0.50 |
+| **Batch API output** | R$ 20.00 | R$ 10.00 | R$ 2.00 |
 
 <small>¹ Reused input tokens are charged at a 75% discount (1/4 of the price). Learn more at [Prompt Caching](prompt-caching).</small>
 

--- a/documentation/docs/pt/introducao.md
+++ b/documentation/docs/pt/introducao.md
@@ -54,6 +54,136 @@ A cobrança pelo uso dos modelos é baseada no volume de tokens, considerando ta
 
 Graças ao nosso treinamento especializado em português e em contextos brasileiros, nossos modelos apresentam excelente desempenho em benchmarks nacionais, com custos significativamente menores do que alternativas comparáveis.
 
+### Sabiá 4 Thinking
+
+Sabiá 4 Thinking é o modelo de raciocínio da família Sabiá: alcança qualidade de fronteira em português e contextos brasileiros pelo menor custo entre os modelos avaliados. Em relação ao Sabiá 4, traz ganhos expressivos em uso de ferramentas, tarefas jurídicas e qualidade das respostas.
+
+A tabela abaixo traz o desempenho do Sabiá 4 Thinking, benchmark a benchmark, frente aos principais modelos de fronteira, em três frentes: chamada de função e agentes, jurídico e tarefas gerais. Os concorrentes (Gemini 3.1 Pro, GPT-5.4 e Opus 4.8) foram avaliados com *reasoning effort* medium. Rodar a suíte completa custa, no Sabiá 4 Thinking, menos da metade do GPT-5.4 e cerca de um terço do Opus 4.8. Em **negrito**, o melhor de cada linha.
+
+<style>{`
+  .bench-thinking { margin: 1.75rem auto; border: 1px solid #e5e7eb; border-radius: 12px; background: #fff; overflow-x: auto; }
+  .bench-thinking table { width: 100%; table-layout: fixed; border-collapse: collapse; }
+  .bench-thinking caption { padding: 1rem 1.25rem; font-weight: 700; font-size: 0.95rem; text-align: center; color: #0f172a; }
+  .bench-thinking th, .bench-thinking td { padding: 0.6rem 0.5rem; border-bottom: 1px solid #e5e7eb; text-align: center; vertical-align: middle; font-size: 0.82rem; }
+  .bench-thinking thead th { background: #111827; color: #f8fafc; text-transform: uppercase; letter-spacing: 0.02em; font-size: 0.72rem; white-space: normal; line-height: 1.25; }
+  .bench-thinking thead th .eff { display: block; text-transform: none; font-weight: 400; font-size: 0.9em; opacity: 0.7; letter-spacing: 0; margin-top: 3px; }
+  .bench-thinking th:nth-child(1), .bench-thinking td:nth-child(1) { text-align: left; width: 32%; }
+  .bench-thinking th:nth-child(2), .bench-thinking td:nth-child(2) { background: #e8f9f1; color: #0f172a; font-weight: 600; }
+  .bench-thinking tbody tr:nth-child(odd) { background: #f9fafb; }
+  .bench-thinking td.grp { text-align: left; background: #fff; color: #ea580c; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; padding-top: 1rem; padding-bottom: 0.35rem; }
+  .bench-thinking .src { color: #94a3b8; font-weight: 400; }
+  [data-theme='dark'] .bench-thinking { border-color: #262626; background: #0f1115; }
+  [data-theme='dark'] .bench-thinking th, [data-theme='dark'] .bench-thinking td { border-color: #262626; color: #e5e7eb; }
+  [data-theme='dark'] .bench-thinking thead th { background: #1f2937; color: #f8fafc; }
+  [data-theme='dark'] .bench-thinking tbody tr:nth-child(odd) { background: #161922; }
+  [data-theme='dark'] .bench-thinking td:nth-child(2) { background: rgba(110,212,75,0.14); color: #e5e7eb; }
+  [data-theme='dark'] .bench-thinking td.grp { background: #0f1115; color: #fb923c; }
+`}</style>
+
+<div className="bench-thinking">
+  <table>
+    <caption>Sabiá 4 Thinking — desempenho por benchmark vs. modelos de fronteira</caption>
+    <thead>
+      <tr>
+        <th>Benchmark</th>
+        <th>Sabiá 4<br/>Thinking</th>
+        <th>Gemini 3.1 Pro<span className="eff">(effort medium)</span></th>
+        <th>GPT-5.4<span className="eff">(effort medium)</span></th>
+        <th>Opus 4.8<span className="eff">(effort medium)</span></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Custo total <span className="src">· R$ para rodar a suíte</span></td>
+        <td><strong>R$ 206</strong></td>
+        <td>R$ 281</td>
+        <td>R$ 449</td>
+        <td>R$ 590</td>
+      </tr>
+      <tr><td className="grp" colSpan={5}>Chamada de função / Agentes</td></tr>
+      <tr>
+        <td>Pix-Bench <span className="src">· interno</span></td>
+        <td><strong>100%</strong></td>
+        <td><strong>100%</strong></td>
+        <td><strong>100%</strong></td>
+        <td>97%</td>
+      </tr>
+      <tr>
+        <td>Ticket-Bench <span className="src">· público</span></td>
+        <td>98%</td>
+        <td><strong>100%</strong></td>
+        <td>98%</td>
+        <td>96,7%</td>
+      </tr>
+      <tr>
+        <td>MARCA <span className="src">· público</span></td>
+        <td>83,9%</td>
+        <td>84,8%</td>
+        <td><strong>93,2%</strong></td>
+        <td>91,5%</td>
+      </tr>
+      <tr><td className="grp" colSpan={5}>Jurídico</td></tr>
+      <tr>
+        <td>OAB (juiz) <span className="src">· interno</span></td>
+        <td>90,1%</td>
+        <td>91,1%</td>
+        <td><strong>91,6%</strong></td>
+        <td>90,1%</td>
+      </tr>
+      <tr>
+        <td>Redação jurídica <span className="src">· interno</span></td>
+        <td><strong>77,7%</strong></td>
+        <td>75,9%</td>
+        <td>72,8%</td>
+        <td>74,8%</td>
+      </tr>
+      <tr>
+        <td>Extração de processos <span className="src">· interno</span></td>
+        <td>92,3%</td>
+        <td>91,4%</td>
+        <td><strong>95,7%</strong></td>
+        <td>94,3%</td>
+      </tr>
+      <tr><td className="grp" colSpan={5}>Geral</td></tr>
+      <tr>
+        <td>BLUEX <span className="src">· público</span></td>
+        <td>93%</td>
+        <td><strong>96,8%</strong></td>
+        <td>95,7%</td>
+        <td>95,4%</td>
+      </tr>
+      <tr>
+        <td>ENAMED <span className="src">· público</span></td>
+        <td>94,4%</td>
+        <td><strong>98,9%</strong></td>
+        <td>97,8%</td>
+        <td>97,8%</td>
+      </tr>
+      <tr>
+        <td>POSCOMP <span className="src">· público</span></td>
+        <td>90,8%</td>
+        <td>94,6%</td>
+        <td>94,6%</td>
+        <td><strong>96,2%</strong></td>
+      </tr>
+      <tr>
+        <td>PoETa v2 <span className="src">· público</span></td>
+        <td>83,7%</td>
+        <td>85%</td>
+        <td>83,3%</td>
+        <td><strong>86,3%</strong></td>
+      </tr>
+      <tr>
+        <td>Sotaques Digitais <span className="src">· público</span></td>
+        <td>94,6%</td>
+        <td>97,6%</td>
+        <td><strong>97,8%</strong></td>
+        <td><strong>97,8%</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
 ### Sabiá 4
 
 Leia o [artigo técnico (arXiv)](https://arxiv.org/abs/2603.10213) para mais detalhes sobre o Sabiá 4.
@@ -64,7 +194,22 @@ O Sabiá 4 tem uma maior acurácia em Leis Brasileiras e melhorias consistentes 
 
 Essa combinação reforça o Sabiá 4 como escolha equilibrada para aplicações jurídicas, educacionais e institucionais no Brasil que exigem contexto local e boa relação custo-desempenho.
 
-<div className="benchmark-table">
+<style>{`
+  .bench-thinking.wide table { table-layout: auto; min-width: 980px; }
+  .bench-thinking.wide thead th { white-space: nowrap; }
+  .bench-thinking.wide th:nth-child(2), .bench-thinking.wide td:nth-child(2) { display: none; }
+  .bench-thinking.wide th:nth-child(1), .bench-thinking.wide td:nth-child(1) { width: auto; }
+  .bench-thinking.wide th:nth-child(2), .bench-thinking.wide td:nth-child(2), .bench-thinking.wide th:nth-child(3), .bench-thinking.wide td:nth-child(3) { text-align: left; }
+  .bench-thinking.wide td:nth-child(2) { background: transparent; color: inherit; font-weight: 400; }
+  .bench-thinking.wide thead th:nth-child(2) { background: #111827; color: #f8fafc; }
+  .bench-thinking.wide th:nth-child(4), .bench-thinking.wide td:nth-child(4) { background: #e8f9f1; color: #0f172a; font-weight: 600; }
+  [data-theme='dark'] .bench-thinking.wide thead th:nth-child(2) { background: #1f2937; color: #f8fafc; }
+  [data-theme='dark'] .bench-thinking.wide thead th:nth-child(4) { background: #1f2937; color: #f8fafc; }
+  [data-theme='dark'] .bench-thinking.wide td:nth-child(2) { background: transparent; color: #e5e7eb; }
+  [data-theme='dark'] .bench-thinking.wide td:nth-child(4) { background: rgba(110,212,75,0.14); color: #e5e7eb; }
+`}</style>
+
+<div className="bench-thinking wide">
   <table>
     <caption>Comparação de desempenho e custo em benchmarks brasileiros</caption>
     <thead>

--- a/documentation/docs/pt/modelos.md
+++ b/documentation/docs/pt/modelos.md
@@ -9,6 +9,12 @@ A Maritaca AI oferece uma gama de modelos na família Sabiá, projetados para at
 
 ## Modelos disponíveis
 
+### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4 Thinking</span></span>
+
+Modelo de raciocínio da família Sabiá, com qualidade de fronteira em português e contextos brasileiros pelo menor custo entre os modelos avaliados. Em relação ao Sabiá 4, traz ganhos expressivos em uso de ferramentas, tarefas jurídicas e qualidade das respostas. Indicado para tarefas complexas que se beneficiam de raciocínio explícito antes da resposta.
+
+**Exemplos de uso:** Resolução de problemas com múltiplas etapas, fluxos agênticos e uso de ferramentas, análise e redação jurídica, e questões de exames e raciocínio técnico.
+
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4</span></span>
 
 Modelo generalista com foco em capacidade agêntica e contexto brasileiro, atualizado até agosto de 2024 e indicado para usos que precisam de precisão e eficiência de custo. Leia o [artigo técnico (arXiv)](https://arxiv.org/abs/2603.10213) para mais detalhes.
@@ -21,23 +27,13 @@ Modelo otimizado para aplicações em larga escala, com foco em velocidade, baix
 
 **Exemplos de uso:** Escrever e revisar peças jurídicas, analisar contratos, aplicar e interpretar leis brasileiras, classificar e extrair informações de documentos, apoiar avaliações educacionais em larga escala e executar fluxos agênticos para automação de tarefas multi-etapas com respostas rápidas e custo menor.
 
-### <span className="inline-title"><span className="geo-icon geo-icon-trophy geo-icon-small" aria-hidden="true"></span><span>Sabiá 3.1</span></span>
-
-Modelo robusto e atualizado até agosto de 2024, com ótimo desempenho em raciocínio matemático, geração/refatoração de código e tarefas que exigem conhecimento amplo.
-
-**Exemplos de uso:** Refatoração e otimização de código legado em múltiplas linguagens, síntese de relatórios de pesquisa clínica e assistente jurídico para revisão de contratos complexos.
-
-### <span className="inline-title"><span className="geo-icon geo-icon-balance geo-icon-small" aria-hidden="true"></span><span>Sabiá 3</span></span> · <span className="inline-title"><span className="geo-icon geo-icon-bolt geo-icon-small" aria-hidden="true"></span><span>Sabiazinho 3</span></span>
-
-Geração anterior dos modelos Sabiá.
-
 ## Especificações
 
-| | **Sabiá 4** | **Sabiazinho 4** | **Sabiá 3.1** | **Sabiá 3** | **Sabiazinho 3** |
-|---|---|---|---|---|---|
-| **Contexto máximo** | 128K | 128K | 128K | 128K | 32K |
-| **Dados de treinamento** | Até ago/2024 | Até ago/2024 | Até ago/2024 | Até meados de 2023 | Até meados de 2023 |
-| **Nomes aceitos (alias)** | sabia-4<br />sabia-4-2026-01-06 | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabia-3.1<br />sabiá-3.1<br />sabia-3.1-2025-05-08<br />sabiá-3.1-2025-05-08 | sabia-3<br />sabiá-3<br />sabia-3-2024-12-11<br />sabiá-3-2024-12-11 | sabiazinho-3<br />sabiazinho-3-2025-02-06<br />sabia-3-small<br />sabiazim-3 |
+| | **Sabiá 4 Thinking** | **Sabiá 4** | **Sabiazinho 4** |
+|---|---|---|---|
+| **Contexto máximo** | 128K | 128K | 128K |
+| **Dados de treinamento** | Até ago/2024 | Até ago/2024 | Até ago/2024 |
+| **Nomes aceitos (alias)** | sabia-4-thinking | sabia-4<br />sabia-4-2026-01-06 | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 |
 
 Para informações sobre preços, consulte a página de [Preços](precos).
 

--- a/documentation/docs/pt/precos.md
+++ b/documentation/docs/pt/precos.md
@@ -7,17 +7,17 @@ title: Preços
 
 Todos os preços são por milhão de tokens processados. A cobrança considera tanto tokens de input quanto de output.
 
-| | **Sabiá 4** | **Sabiazinho 4** | **Sabiá 3.1** | **Sabiá 3** | **Sabiazinho 3** |
-|---|---|---|---|---|---|
-| **Input** | R$ 5,00 | R$ 1,00 | R$ 5,00 | R$ 5,00 | R$ 1,00 |
-| **Output** | R$ 20,00 | R$ 4,00 | R$ 10,00 | R$ 10,00 | R$ 3,00 |
-| **Input em cache ¹** | R$ 1,25 | R$ 0,25 | R$ 1,25 | R$ 1,25 | R$ 0,25 |
-| **Input noturno ²** | R$ 3,50 | R$ 0,70 | R$ 3,50 | R$ 3,50 | R$ 0,70 |
-| **Output noturno ²** | R$ 14,00 | R$ 2,80 | R$ 7,00 | R$ 7,00 | R$ 2,10 |
-| **Input Flex ³** | R$ 2,50 | R$ 0,50 | R$ 2,50 | R$ 2,50 | R$ 0,50 |
-| **Output Flex ³** | R$ 10,00 | R$ 2,00 | R$ 5,00 | R$ 5,00 | R$ 1,50 |
-| **Input Batch API** | R$ 2,50 | R$ 0,50 | R$ 2,50 | R$ 2,50 | R$ 0,50 |
-| **Output Batch API** | R$ 10,00 | R$ 2,00 | R$ 5,00 | R$ 5,00 | R$ 1,50 |
+| | **Sabiá 4 Thinking** | **Sabiá 4** | **Sabiazinho 4** |
+|---|---|---|---|
+| **Input** | R$ 5,00 | R$ 5,00 | R$ 1,00 |
+| **Output** | R$ 40,00 | R$ 20,00 | R$ 4,00 |
+| **Input em cache ¹** | R$ 1,25 | R$ 1,25 | R$ 0,25 |
+| **Input noturno ²** | R$ 3,50 | R$ 3,50 | R$ 0,70 |
+| **Output noturno ²** | R$ 28,00 | R$ 14,00 | R$ 2,80 |
+| **Input Flex ³** | R$ 2,50 | R$ 2,50 | R$ 0,50 |
+| **Output Flex ³** | R$ 20,00 | R$ 10,00 | R$ 2,00 |
+| **Input Batch API** | R$ 2,50 | R$ 2,50 | R$ 0,50 |
+| **Output Batch API** | R$ 20,00 | R$ 10,00 | R$ 2,00 |
 
 <small>¹ Tokens de input reutilizados entre requisições são cobrados com 75% de desconto (1/4 do preço). Saiba mais em [Cache de Prompt](cache-de-prompt).</small>
 


### PR DESCRIPTION
## Resumo

Adiciona o **Sabiá 4 Thinking** à documentação e remove os modelos antigos (Sabiá 3.1, Sabiá 3 e Sabiazinho 3).

### Preços (`docs/pt/precos.md`, `docs/en/precos.md`)
- Nova coluna **Sabiá 4 Thinking**: input R$ 5 / output R$ 40 (cache, noturno, Flex e Batch derivados dos mesmos descontos dos demais modelos)
- Removidas as colunas Sabiá 3.1, Sabiá 3 e Sabiazinho 3

### Modelos (`docs/pt/modelos.md`, `docs/en/models.md`)
- Nova seção e linha de especificações do Sabiá 4 Thinking (contexto 128K, treino até ago/2024, alias `sabia-4-thinking`), posicionado **antes** do Sabiá 4
- Removidos os 3 modelos antigos das seções e da tabela de especificações

### Introdução (`docs/pt/introducao.md`, `docs/en/introduction.md`)
- Nova seção **Sabiá 4 Thinking** em Desempenho, com tabela **por benchmark** comparando contra Gemini 3.1 Pro, GPT-5.4 e Opus 4.8 (effort medium), iniciando por uma linha de **Custo total**
- Estilo das duas tabelas de desempenho unificado (mesmo cabeçalho, destaque na coluna do modelo Sabiá)
- Coluna **Descrição** removida da tabela do Sabiá 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
