### PR TITLE
docs(models): add Sabiá 4 BR-SP e Sabiá 4 Thinking BR-SP

### DIFF
--- a/documentation/docs/en/introduction.md
+++ b/documentation/docs/en/introduction.md
@@ -18,7 +18,7 @@ The Sabiá family of models, developed by Maritaca AI, can simulate human intera
   <div className="intro-feature-card">
     <span className="geo-icon geo-icon-context" aria-hidden="true"></span>
     <h3>Provide Information</h3>
-    <p>It can follow the context of a conversation and adjust responses accordingly, providing up-to-date information up to its cutoff date, such as details about historical events, science, technology, culture, and more.</p>
+    <p>It can follow the context of a conversation and adjust responses accordingly, providing information about historical events, science, technology, culture, and more.</p>
   </div>
   <div className="intro-feature-card">
     <span className="geo-icon geo-icon-translate" aria-hidden="true"></span>
@@ -43,7 +43,7 @@ The Sabiá family of models, developed by Maritaca AI, can simulate human intera
   <div className="intro-feature-card">
     <span className="geo-icon geo-icon-data" aria-hidden="true"></span>
     <h3>Data analysis</h3>
-    <p>It can help interpret and analyze provided data that do not require updates after the cutoff date.</p>
+    <p>It can help interpret and analyze provided data.</p>
   </div>
 </div>
 

--- a/documentation/docs/en/models.md
+++ b/documentation/docs/en/models.md
@@ -15,11 +15,19 @@ The reasoning model of the Sabiá family, delivering frontier quality in Portugu
 
 **Example use cases:** Multi-step problem solving, agentic workflows and tool use, legal analysis and drafting, and exam questions and technical reasoning.
 
+### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4 Thinking BR-SP</span></span>
+
+The same Sabiá 4 Thinking model, with **inference and processing performed entirely (100%) within Brazilian territory** — intended for use cases that require Brazilian data sovereignty and residency. Capabilities, context, and training data are identical to Sabiá 4 Thinking; pricing is 30% higher. API model name: `sabia-4-thinking-br-sp`.
+
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4</span></span>
 
 General-purpose model focused on agentic capability and Brazilian context, updated through August 2024 and recommended for uses that need accuracy with cost efficiency. Read the [technical paper (arXiv)](https://arxiv.org/abs/2603.10213) for more details.
 
 **Example use cases:** Drafting and reviewing briefs and opinions, tutoring for exams, analyzing and synthesizing long documents, and orchestrating multi-step agentic workflows.
+
+### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4 BR-SP</span></span>
+
+The same Sabiá 4 model, with **inference and processing performed entirely (100%) within Brazilian territory** — intended for use cases that require Brazilian data sovereignty and residency. Capabilities, context, and training data are identical to Sabiá 4; pricing is 30% higher. API model name: `sabia-4-br-sp`.
 
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiazinho 4</span></span>
 
@@ -33,11 +41,11 @@ The same Sabiazinho 4 model, with **inference and processing performed entirely 
 
 ## Specifications
 
-| | **Sabiá 4 Thinking** | **Sabiá 4** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
-|---|---|---|---|---|
-| **Max context** | 128K | 128K | 128K | 128K |
-| **Training data cutoff** | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 |
-| **Model names/aliases** | sabia-4-thinking | sabia-4<br />sabia-4-2026-01-06 | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
+| | **Sabiá 4 Thinking** | **Sabiá 4 Thinking BR-SP** | **Sabiá 4** | **Sabiá 4 BR-SP** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
+|---|---|---|---|---|---|---|
+| **Max context** | 128K | 128K | 128K | 128K | 128K | 128K |
+| **Training data cutoff** | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 |
+| **Model names/aliases** | sabia-4-thinking | sabia-4-thinking-br-sp | sabia-4<br />sabia-4-2026-01-06 | sabia-4-br-sp | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
 
 For pricing information, see the [Pricing](precos) page.
 

--- a/documentation/docs/en/models.md
+++ b/documentation/docs/en/models.md
@@ -17,7 +17,7 @@ The reasoning model of the Sabiá family, delivering frontier quality in Portugu
 
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4 Thinking BR-SP</span></span>
 
-The same Sabiá 4 Thinking model, with **inference and processing performed entirely (100%) within Brazilian territory** — intended for use cases that require Brazilian data sovereignty and residency. Capabilities, context, and training data are identical to Sabiá 4 Thinking; pricing is 30% higher. API model name: `sabia-4-thinking-br-sp`.
+The same Sabiá 4 Thinking model, with **inference and processing performed entirely (100%) within Brazilian territory** — intended for use cases that require Brazilian data residency. Capabilities, context, and training data are identical to Sabiá 4 Thinking; pricing is 30% higher. API model name: `sabia-4-thinking-br-sp`.
 
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4</span></span>
 

--- a/documentation/docs/en/models.md
+++ b/documentation/docs/en/models.md
@@ -21,7 +21,7 @@ The same Sabiá 4 Thinking model, with **inference and processing performed enti
 
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4</span></span>
 
-General-purpose model focused on agentic capability and Brazilian context, updated through August 2024 and recommended for uses that need accuracy with cost efficiency. Read the [technical paper (arXiv)](https://arxiv.org/abs/2603.10213) for more details.
+General-purpose model focused on agentic capability and Brazilian context, recommended for uses that need accuracy with cost efficiency. Read the [technical paper (arXiv)](https://arxiv.org/abs/2603.10213) for more details.
 
 **Example use cases:** Drafting and reviewing briefs and opinions, tutoring for exams, analyzing and synthesizing long documents, and orchestrating multi-step agentic workflows.
 
@@ -44,7 +44,6 @@ The same Sabiazinho 4 model, with **inference and processing performed entirely 
 | | **Sabiá 4 Thinking** | **Sabiá 4 Thinking BR-SP** | **Sabiá 4** | **Sabiá 4 BR-SP** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
 |---|---|---|---|---|---|---|
 | **Max context** | 128K | 128K | 128K | 128K | 128K | 128K |
-| **Training data cutoff** | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 | Through Aug 2024 |
 | **Model names/aliases** | sabia-4-thinking | sabia-4-thinking-br-sp | sabia-4<br />sabia-4-2026-01-06 | sabia-4-br-sp | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
 
 For pricing information, see the [Pricing](precos) page.

--- a/documentation/docs/en/precos.md
+++ b/documentation/docs/en/precos.md
@@ -29,21 +29,21 @@ All prices are per million tokens processed. Billing considers both input and ou
 The cache discount (75%) applies only to cached input tokens. Batch API, Flex, and off-peak discounts apply only to non-cached input tokens and output tokens — they do not multiply with the cache discount. Additionally, Batch API, Flex, and off-peak are mutually exclusive. See more details at [Prompt Caching](prompt-caching#how-discounts-interact).
 :::
 
-## Sabiazinho 4 BR-SP
+## BR-SP models
 
-Sabiazinho 4 BR-SP has the same prices as Sabiazinho 4 plus 30% — inference and processing performed 100% within Brazilian territory. API model name: `sabiazinho-4-br-sp`.
+BR-SP models perform inference and processing entirely (100%) within Brazilian territory, priced 30% above the corresponding model. API model names: `sabia-4-thinking-br-sp`, `sabia-4-br-sp`, `sabiazinho-4-br-sp`.
 
-| | **Sabiazinho 4 BR-SP** |
-|---|---|
-| **Input** | R$ 1.30 |
-| **Output** | R$ 5.20 |
-| **Cached input ¹** | R$ 0.33 |
-| **Off-peak input ²** | R$ 0.91 |
-| **Off-peak output ²** | R$ 3.64 |
-| **Flex input ³** | R$ 0.65 |
-| **Flex output ³** | R$ 2.60 |
-| **Batch API input** | R$ 0.65 |
-| **Batch API output** | R$ 2.60 |
+| | **Sabiá 4 Thinking BR-SP** | **Sabiá 4 BR-SP** | **Sabiazinho 4 BR-SP** |
+|---|---|---|---|
+| **Input** | R$ 6.50 | R$ 6.50 | R$ 1.30 |
+| **Output** | R$ 52.00 | R$ 26.00 | R$ 5.20 |
+| **Cached input ¹** | R$ 1.63 | R$ 1.63 | R$ 0.33 |
+| **Off-peak input ²** | R$ 4.55 | R$ 4.55 | R$ 0.91 |
+| **Off-peak output ²** | R$ 36.40 | R$ 18.20 | R$ 3.64 |
+| **Flex input ³** | R$ 3.25 | R$ 3.25 | R$ 0.65 |
+| **Flex output ³** | R$ 26.00 | R$ 13.00 | R$ 2.60 |
+| **Batch API input** | R$ 3.25 | R$ 3.25 | R$ 0.65 |
+| **Batch API output** | R$ 26.00 | R$ 13.00 | R$ 2.60 |
 
 ## How do I know how many tokens I will be charged?
 

--- a/documentation/docs/pt/introducao.md
+++ b/documentation/docs/pt/introducao.md
@@ -18,7 +18,7 @@ A cobrança pelo uso dos modelos é baseada no volume de tokens, considerando ta
   <div className="intro-feature-card">
     <span className="geo-icon geo-icon-context" aria-hidden="true"></span>
     <h3>Auxiliar com Informações</h3>
-    <p>Pode seguir o contexto de uma conversa e ajustar as respostas de acordo com a situação, fornecendo informações atualizadas até sua data de corte, como detalhes sobre eventos históricos, ciência, tecnologia, cultura e muito mais.</p>
+    <p>Pode seguir o contexto de uma conversa e ajustar as respostas de acordo com a situação, fornecendo informações sobre eventos históricos, ciência, tecnologia, cultura e muito mais.</p>
   </div>
   <div className="intro-feature-card">
     <span className="geo-icon geo-icon-translate" aria-hidden="true"></span>
@@ -43,7 +43,7 @@ A cobrança pelo uso dos modelos é baseada no volume de tokens, considerando ta
   <div className="intro-feature-card">
     <span className="geo-icon geo-icon-data" aria-hidden="true"></span>
     <h3>Análise de dados</h3>
-    <p>Pode ajudar a interpretar e analisar dados fornecidos que não exijam atualizações após a data de corte.</p>
+    <p>Pode ajudar a interpretar e analisar dados fornecidos.</p>
   </div>
 </div>
 

--- a/documentation/docs/pt/modelos.md
+++ b/documentation/docs/pt/modelos.md
@@ -27,7 +27,7 @@ Modelo generalista com foco em capacidade agêntica e contexto brasileiro, atual
 
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4 BR-SP</span></span>
 
-O mesmo modelo Sabiá 4, com **inferência e processamento realizados 100% em território nacional** — indicado para casos de uso que exigem soberania e residência de dados no Brasil. Capacidades, contexto e dados de treinamento são idênticos ao Sabiá 4; o custo é 30% superior. Nome aceito na API: `sabia-4-br-sp`.
+O mesmo modelo Sabiá 4, com **inferência e processamento realizados 100% em território nacional** — indicado para casos de uso que exigem residência de dados no Brasil. Capacidades, contexto e dados de treinamento são idênticos ao Sabiá 4; o custo é 30% superior. Nome aceito na API: `sabia-4-br-sp`.
 
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiazinho 4</span></span>
 

--- a/documentation/docs/pt/modelos.md
+++ b/documentation/docs/pt/modelos.md
@@ -21,7 +21,7 @@ O mesmo modelo Sabiá 4 Thinking, com **inferência e processamento realizados 1
 
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4</span></span>
 
-Modelo generalista com foco em capacidade agêntica e contexto brasileiro, atualizado até agosto de 2024 e indicado para usos que precisam de precisão e eficiência de custo. Leia o [artigo técnico (arXiv)](https://arxiv.org/abs/2603.10213) para mais detalhes.
+Modelo generalista com foco em capacidade agêntica e contexto brasileiro, indicado para usos que precisam de precisão e eficiência de custo. Leia o [artigo técnico (arXiv)](https://arxiv.org/abs/2603.10213) para mais detalhes.
 
 **Exemplos de uso:** Elaboração e revisão de peças e pareceres, tutoria para provas, análise e síntese de documentos longos e orquestração de fluxos agênticos multi-etapas.
 
@@ -44,7 +44,6 @@ O mesmo modelo Sabiazinho 4, com **inferência e processamento realizados 100% e
 | | **Sabiá 4 Thinking** | **Sabiá 4 Thinking BR-SP** | **Sabiá 4** | **Sabiá 4 BR-SP** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
 |---|---|---|---|---|---|---|
 | **Contexto máximo** | 128K | 128K | 128K | 128K | 128K | 128K |
-| **Dados de treinamento** | Até ago/2024 | Até ago/2024 | Até ago/2024 | Até ago/2024 | Até ago/2024 | Até ago/2024 |
 | **Nomes aceitos (alias)** | sabia-4-thinking | sabia-4-thinking-br-sp | sabia-4<br />sabia-4-2026-01-06 | sabia-4-br-sp | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
 
 Para informações sobre preços, consulte a página de [Preços](precos).

--- a/documentation/docs/pt/modelos.md
+++ b/documentation/docs/pt/modelos.md
@@ -15,11 +15,19 @@ Modelo de raciocínio da família Sabiá, com qualidade de fronteira em portugu�
 
 **Exemplos de uso:** Resolução de problemas com múltiplas etapas, fluxos agênticos e uso de ferramentas, análise e redação jurídica, e questões de exames e raciocínio técnico.
 
+### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4 Thinking BR-SP</span></span>
+
+O mesmo modelo Sabiá 4 Thinking, com **inferência e processamento realizados 100% em território nacional** — indicado para casos de uso que exigem soberania e residência de dados no Brasil. Capacidades, contexto e dados de treinamento são idênticos ao Sabiá 4 Thinking; o custo é 30% superior. Nome aceito na API: `sabia-4-thinking-br-sp`.
+
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4</span></span>
 
 Modelo generalista com foco em capacidade agêntica e contexto brasileiro, atualizado até agosto de 2024 e indicado para usos que precisam de precisão e eficiência de custo. Leia o [artigo técnico (arXiv)](https://arxiv.org/abs/2603.10213) para mais detalhes.
 
 **Exemplos de uso:** Elaboração e revisão de peças e pareceres, tutoria para provas, análise e síntese de documentos longos e orquestração de fluxos agênticos multi-etapas.
+
+### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4 BR-SP</span></span>
+
+O mesmo modelo Sabiá 4, com **inferência e processamento realizados 100% em território nacional** — indicado para casos de uso que exigem soberania e residência de dados no Brasil. Capacidades, contexto e dados de treinamento são idênticos ao Sabiá 4; o custo é 30% superior. Nome aceito na API: `sabia-4-br-sp`.
 
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiazinho 4</span></span>
 
@@ -33,11 +41,11 @@ O mesmo modelo Sabiazinho 4, com **inferência e processamento realizados 100% e
 
 ## Especificações
 
-| | **Sabiá 4 Thinking** | **Sabiá 4** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
-|---|---|---|---|---|
-| **Contexto máximo** | 128K | 128K | 128K | 128K |
-| **Dados de treinamento** | Até ago/2024 | Até ago/2024 | Até ago/2024 | Até ago/2024 |
-| **Nomes aceitos (alias)** | sabia-4-thinking | sabia-4<br />sabia-4-2026-01-06 | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
+| | **Sabiá 4 Thinking** | **Sabiá 4 Thinking BR-SP** | **Sabiá 4** | **Sabiá 4 BR-SP** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
+|---|---|---|---|---|---|---|
+| **Contexto máximo** | 128K | 128K | 128K | 128K | 128K | 128K |
+| **Dados de treinamento** | Até ago/2024 | Até ago/2024 | Até ago/2024 | Até ago/2024 | Até ago/2024 | Até ago/2024 |
+| **Nomes aceitos (alias)** | sabia-4-thinking | sabia-4-thinking-br-sp | sabia-4<br />sabia-4-2026-01-06 | sabia-4-br-sp | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
 
 Para informações sobre preços, consulte a página de [Preços](precos).
 

--- a/documentation/docs/pt/precos.md
+++ b/documentation/docs/pt/precos.md
@@ -29,21 +29,21 @@ Todos os preços são por milhão de tokens processados. A cobrança considera t
 O desconto de cache (75%) se aplica apenas aos tokens de input em cache. Os descontos de Batch API, Flex e horário noturno se aplicam apenas aos tokens de input não cacheados e de output — eles não se multiplicam com o desconto de cache. Além disso, Batch API, Flex e horário noturno são mutuamente exclusivos. Veja mais detalhes em [Cache de Prompt](cache-de-prompt#como-os-descontos-interagem).
 :::
 
-## Sabiazinho 4 BR-SP
+## Modelos BR-SP
 
-O Sabiazinho 4 BR-SP tem os mesmos preços do Sabiazinho 4 acrescidos de 30% — inferência e processamento 100% em território nacional. Nome na API: `sabiazinho-4-br-sp`.
+Os modelos BR-SP têm inferência e processamento realizados 100% em território nacional, com os mesmos preços do modelo correspondente acrescidos de 30%. Nomes na API: `sabia-4-thinking-br-sp`, `sabia-4-br-sp`, `sabiazinho-4-br-sp`.
 
-| | **Sabiazinho 4 BR-SP** |
-|---|---|
-| **Input** | R$ 1,30 |
-| **Output** | R$ 5,20 |
-| **Input em cache ¹** | R$ 0,33 |
-| **Input noturno ²** | R$ 0,91 |
-| **Output noturno ²** | R$ 3,64 |
-| **Input Flex ³** | R$ 0,65 |
-| **Output Flex ³** | R$ 2,60 |
-| **Input Batch API** | R$ 0,65 |
-| **Output Batch API** | R$ 2,60 |
+| | **Sabiá 4 Thinking BR-SP** | **Sabiá 4 BR-SP** | **Sabiazinho 4 BR-SP** |
+|---|---|---|---|
+| **Input** | R$ 6,50 | R$ 6,50 | R$ 1,30 |
+| **Output** | R$ 52,00 | R$ 26,00 | R$ 5,20 |
+| **Input em cache ¹** | R$ 1,63 | R$ 1,63 | R$ 0,33 |
+| **Input noturno ²** | R$ 4,55 | R$ 4,55 | R$ 0,91 |
+| **Output noturno ²** | R$ 36,40 | R$ 18,20 | R$ 3,64 |
+| **Input Flex ³** | R$ 3,25 | R$ 3,25 | R$ 0,65 |
+| **Output Flex ³** | R$ 26,00 | R$ 13,00 | R$ 2,60 |
+| **Input Batch API** | R$ 3,25 | R$ 3,25 | R$ 0,65 |
+| **Output Batch API** | R$ 26,00 | R$ 13,00 | R$ 2,60 |
 
 ## Como saber quantos tokens serei cobrado?
 


### PR DESCRIPTION
## What
Documenta dois novos modelos de **território nacional**, espelhando o `Sabiazinho 4 BR-SP`:
- **Sabiá 4 BR-SP** (`sabia-4-br-sp`) — mesmo Sabiá 4, inferência/processamento 100% em território nacional
- **Sabiá 4 Thinking BR-SP** (`sabia-4-thinking-br-sp`) — mesmo Sabiá 4 Thinking, idem

Preço: **30% acima** do modelo correspondente.

## Changes
- `pt/modelos.md` + `en/models.md`: 2 novas seções (logo após cada modelo-base) + 2 colunas novas na tabela de Especificações (agora 6 modelos).
- `pt/precos.md` + `en/precos.md`: consolidei a antiga seção "Sabiazinho 4 BR-SP" numa única seção **"Modelos BR-SP"** com tabela de 3 colunas (Sabiá 4 Thinking BR-SP | Sabiá 4 BR-SP | Sabiazinho 4 BR-SP). Preços = base ×1,3.

## Notas
- Tabela de Especificações ficou com 6 colunas de modelo (rola horizontalmente em telas estreitas) — consistente com a decisão de dar coluna ao BR-SP.
- Pareia com a PR de backend em `maritaca-ai/maritalk` (definição do modelo + preços + rate-limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)