### PR TITLE
docs(tools): corrige disponibilidade das ferramentas integradas por modelo

### DIFF
--- a/documentation/docs/en/tools.md
+++ b/documentation/docs/en/tools.md
@@ -7,19 +7,19 @@ title: Built-in Tools
 
 Built-in tools let Sabiá models **search the web, run code, and query official Brazilian databases on the server side**, without you having to implement or host anything. Unlike [function calls](function-call.md) — which the model delegates back to *your* code — built-in tools run inside Maritaca's infrastructure as an agentic flow: the model decides which tools to call, calls them across multiple steps, and returns only the final answer. The intermediate reasoning and tool calls stay internal.
 
-Built-in tools are available on the agentic Sabiá-4 family: **`sabia-4`**, **`sabia-4-thinking`**, and **`sabiazinho-4`**.
+Availability varies by tool: **web search** works on all Sabiá models, while **code execution** and **Data Ocean** are available only on **`sabia-4-thinking`**.
 
 ## Available tools
 
-| Tool | Flag | What it does |
-|---|---|---|
-| **Web search** | `web_search` | Searches the web and reads pages to answer with up-to-date information and sources. |
-| **Code execution** | `code_execution` | Runs Python/Bash in a sandbox to compute, analyze data, and generate files (charts, documents). |
-| **Data Ocean** | `data_ocean` | Queries dozens of official Brazilian databases — population, companies, health, climate, public safety, economy, elections, and more — to answer with real figures and sources. |
+| Tool | Flag | Models | What it does |
+|---|---|---|---|
+| **Web search** | `web_search` | All Sabiá models | Searches the web and reads pages to answer with up-to-date information and sources. |
+| **Code execution** | `code_execution` | `sabia-4-thinking` only | Runs Python/Bash in a sandbox to compute, analyze data, and generate files (charts, documents). |
+| **Data Ocean** | `data_ocean` | `sabia-4-thinking` only | Queries dozens of official Brazilian databases — population, companies, health, climate, public safety, economy, elections, and more — to answer with real figures and sources. |
 
 ## Enabling tools
 
-Built-in tools require **`stream: false`** (the agentic flow returns only the final answer) and an agentic Sabiá-4 model. They are **off by default** — you opt in per request.
+Built-in tools require **`stream: false`** (the agentic flow returns only the final answer) and a compatible model (see the table above). They are **off by default** — you opt in per request.
 
 ### Chat Completions
 
@@ -172,5 +172,5 @@ Built-in tool executions are billed per use, in addition to the usual token cost
 ## Notes and limitations
 
 - **Streaming is not supported** with built-in tools — send `stream: false`. A streaming request that enables a tool returns a `400` error.
-- **Agentic Sabiá-4 models only** (`sabia-4`, `sabia-4-thinking`, `sabiazinho-4`). On other models the flags are ignored.
+- **Availability depends on the tool**: web search (`web_search`) works on all Sabiá models; code execution (`code_execution`) and Data Ocean (`data_ocean`) work only on `sabia-4-thinking`. On incompatible models the flags are ignored.
 - The agentic flow is **internal**: intermediate reasoning and tool calls are not exposed — only the final assistant message (plus any generated files) is returned.

--- a/documentation/docs/pt/ferramentas.md
+++ b/documentation/docs/pt/ferramentas.md
@@ -7,19 +7,19 @@ title: Ferramentas integradas
 
 As ferramentas integradas permitem que os modelos Sabiá **busquem na web, executem código e consultem bases de dados oficiais brasileiras no lado do servidor**, sem que você precise implementar ou hospedar nada. Diferentemente da [chamada de funções](chamada-funcao.md) — em que o modelo delega de volta para o *seu* código — as ferramentas integradas rodam dentro da infraestrutura da Maritaca como um fluxo agêntico: o modelo decide quais ferramentas chamar, as chama em múltiplos passos e retorna apenas a resposta final. O raciocínio e as chamadas de ferramenta intermediários ficam internos.
 
-As ferramentas integradas estão disponíveis na família agêntica Sabiá-4: **`sabia-4`**, **`sabia-4-thinking`** e **`sabiazinho-4`**.
+A disponibilidade varia por ferramenta: a **Busca na web** funciona em todos os modelos Sabiá, enquanto a **Execução de código** e o **Data Ocean** estão disponíveis apenas no **`sabia-4-thinking`**.
 
 ## Ferramentas disponíveis
 
-| Ferramenta | Flag | O que faz |
-|---|---|---|
-| **Busca na web** | `web_search` | Pesquisa na web e lê páginas para responder com informações atualizadas e fontes. |
-| **Execução de código** | `code_execution` | Executa Python/Bash em um sandbox para calcular, analisar dados e gerar arquivos (gráficos, documentos). |
-| **Data Ocean** | `data_ocean` | Consulta dezenas de bases de dados oficiais brasileiras — população, empresas, saúde, clima, segurança, economia, eleições e mais — para responder com números e fontes reais. |
+| Ferramenta | Flag | Modelos | O que faz |
+|---|---|---|---|
+| **Busca na web** | `web_search` | Todos os modelos Sabiá | Pesquisa na web e lê páginas para responder com informações atualizadas e fontes. |
+| **Execução de código** | `code_execution` | Apenas `sabia-4-thinking` | Executa Python/Bash em um sandbox para calcular, analisar dados e gerar arquivos (gráficos, documentos). |
+| **Data Ocean** | `data_ocean` | Apenas `sabia-4-thinking` | Consulta dezenas de bases de dados oficiais brasileiras — população, empresas, saúde, clima, segurança, economia, eleições e mais — para responder com números e fontes reais. |
 
 ## Ativando as ferramentas
 
-As ferramentas integradas exigem **`stream: false`** (o fluxo agêntico retorna apenas a resposta final) e um modelo agêntico Sabiá-4. Elas vêm **desligadas por padrão** — você as ativa por requisição.
+As ferramentas integradas exigem **`stream: false`** (o fluxo agêntico retorna apenas a resposta final) e um modelo compatível (veja a tabela acima). Elas vêm **desligadas por padrão** — você as ativa por requisição.
 
 ### Chat Completions
 
@@ -172,5 +172,5 @@ As execuções de ferramentas integradas são cobradas por uso, além dos custos
 ## Observações e limitações
 
 - **Streaming não é suportado** com ferramentas integradas — envie `stream: false`. Uma requisição em streaming que ative uma ferramenta retorna um erro `400`.
-- **Apenas modelos agênticos Sabiá-4** (`sabia-4`, `sabia-4-thinking`, `sabiazinho-4`). Em outros modelos as flags são ignoradas.
+- **A disponibilidade depende da ferramenta**: a Busca na web (`web_search`) funciona em todos os modelos Sabiá; a Execução de código (`code_execution`) e o Data Ocean (`data_ocean`) funcionam apenas no `sabia-4-thinking`. Em modelos incompatíveis, as flags são ignoradas.
 - O fluxo agêntico é **interno**: o raciocínio e as chamadas de ferramenta intermediários não são expostos — apenas a mensagem final do assistente (mais eventuais arquivos gerados) é retornada.


### PR DESCRIPTION
## O que muda

Corrige a disponibilidade das ferramentas integradas por modelo na página **Ferramentas integradas** (PT e EN):

- **Busca na web** (`web_search`) → disponível em **todos os modelos Sabiá**
- **Execução de código** (`code_execution`) → apenas **`sabia-4-thinking`**
- **Data Ocean** (`data_ocean`) → apenas **`sabia-4-thinking`**

Antes o texto afirmava que todas as três ferramentas estavam disponíveis em toda a família agêntica Sabiá-4 (`sabia-4`, `sabia-4-thinking`, `sabiazinho-4`).

## Detalhes

- Adiciona uma coluna **Modelos** na tabela de ferramentas
- Atualiza a introdução, a nota de ativação e a seção de observações/limitações
- Espelha as mudanças em `docs/pt/ferramentas.md` e `docs/en/tools.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)