### PR TITLE
docs(models): document max output tokens (32K) and refresh list-models example

### DIFF
--- a/documentation/api/en/list-models-response.md
+++ b/documentation/api/en/list-models-response.md
@@ -65,36 +65,36 @@ Information about the primary provider, including `context_length` and `max_comp
   "object": "list",
   "data": [
     {
-      "id": "sabia-3.1",
-      "created": 1746662400,
+      "id": "sabia-4-thinking",
+      "created": 1781049600,
       "object": "model",
       "owned_by": "maritacaai",
       "context_length": 128000,
       "top_provider": {
         "context_length": 128000,
-        "max_completion_tokens": 12000
+        "max_completion_tokens": 32768
       }
     },
     {
-      "id": "sabia-3",
-      "created": 1733875200,
+      "id": "sabia-4",
+      "created": 1767657600,
       "object": "model",
       "owned_by": "maritacaai",
       "context_length": 128000,
       "top_provider": {
         "context_length": 128000,
-        "max_completion_tokens": 12000
+        "max_completion_tokens": 32768
       }
     },
     {
-      "id": "sabiazinho-3",
-      "created": 1738800000,
+      "id": "sabiazinho-4",
+      "created": 1767657600,
       "object": "model",
       "owned_by": "maritacaai",
-      "context_length": 32000,
+      "context_length": 128000,
       "top_provider": {
-        "context_length": 32000,
-        "max_completion_tokens": 12000
+        "context_length": 128000,
+        "max_completion_tokens": 32768
       }
     }
   ]

--- a/documentation/api/pt/list-models-response.md
+++ b/documentation/api/pt/list-models-response.md
@@ -66,36 +66,36 @@ Informações do provedor principal, incluindo `context_length` e `max_completio
   "object": "list",
   "data": [
     {
-      "id": "sabia-3.1",
-      "created": 1746662400,
+      "id": "sabia-4-thinking",
+      "created": 1781049600,
       "object": "model",
       "owned_by": "maritacaai",
       "context_length": 128000,
       "top_provider": {
         "context_length": 128000,
-        "max_completion_tokens": 12000
+        "max_completion_tokens": 32768
       }
     },
     {
-      "id": "sabia-3",
-      "created": 1733875200,
+      "id": "sabia-4",
+      "created": 1767657600,
       "object": "model",
       "owned_by": "maritacaai",
       "context_length": 128000,
       "top_provider": {
         "context_length": 128000,
-        "max_completion_tokens": 12000
+        "max_completion_tokens": 32768
       }
     },
     {
-      "id": "sabiazinho-3",
-      "created": 1738800000,
+      "id": "sabiazinho-4",
+      "created": 1767657600,
       "object": "model",
       "owned_by": "maritacaai",
-      "context_length": 32000,
+      "context_length": 128000,
       "top_provider": {
-        "context_length": 32000,
-        "max_completion_tokens": 12000
+        "context_length": 128000,
+        "max_completion_tokens": 32768
       }
     }
   ]

--- a/documentation/docs/en/models.md
+++ b/documentation/docs/en/models.md
@@ -44,6 +44,7 @@ The same Sabiazinho 4 model, with **inference and processing performed entirely 
 | | **Sabiá 4 Thinking** | **Sabiá 4 Thinking BR-SP** | **Sabiá 4** | **Sabiá 4 BR-SP** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
 |---|---|---|---|---|---|---|
 | **Max context** | 128K | 128K | 128K | 128K | 128K | 128K |
+| **Max output tokens** | 32K | 32K | 32K | 32K | 32K | 32K |
 | **Model names/aliases** | sabia-4-thinking | sabia-4-thinking-br-sp | sabia-4<br />sabia-4-2026-01-06 | sabia-4-br-sp | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
 
 For pricing information, see the [Pricing](precos) page.

--- a/documentation/docs/pt/modelos.md
+++ b/documentation/docs/pt/modelos.md
@@ -44,6 +44,7 @@ O mesmo modelo Sabiazinho 4, com **inferência e processamento realizados 100% e
 | | **Sabiá 4 Thinking** | **Sabiá 4 Thinking BR-SP** | **Sabiá 4** | **Sabiá 4 BR-SP** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
 |---|---|---|---|---|---|---|
 | **Contexto máximo** | 128K | 128K | 128K | 128K | 128K | 128K |
+| **Máximo de tokens de saída** | 32K | 32K | 32K | 32K | 32K | 32K |
 | **Nomes aceitos (alias)** | sabia-4-thinking | sabia-4-thinking-br-sp | sabia-4<br />sabia-4-2026-01-06 | sabia-4-br-sp | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
 
 Para informações sobre preços, consulte a página de [Preços](precos).


### PR DESCRIPTION
## O que muda

A documentação não trazia o **máximo de tokens de saída** por modelo — a tabela de Especificações mostrava só o contexto (128K). E o exemplo do endpoint `/models` (list-models) estava desatualizado.

### 1. Tabela de Modelos (`models.md` / `modelos.md`, EN + PT)
Adicionada a linha **Max output tokens / Máximo de tokens de saída = 32K** logo abaixo do contexto máximo.

### 2. Exemplo do list-models (`api/{en,pt}/list-models-response.md`)
- `max_completion_tokens`: **12000 → 32768** (o valor realmente aplicado)
- modelos de exemplo trocados da geração `sabia-3` para a família atual: `sabia-4-thinking`, `sabia-4`, `sabiazinho-4`
- `sabiazinho` no exemplo agora com contexto 128000 (era 32000, valor da geração 3)

## De onde vem o 32K

No backend `maritalk`, `settings.api_max_new_tokens = 32768`. É o valor que:
- `/v1/models` serve como `max_completion_tokens` para **todos** os modelos (`routers/chat.py`);
- limita os parâmetros de request `max_tokens` / `max_completion_tokens` (`schemas.py`, `le=settings.api_max_new_tokens`).

Só documentação — sem mudança de comportamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nDTQuJexYaVpbMM671LfG