### PR TITLE
docs: code_execution e data_ocean disponíveis também no sabia-4

### DIFF
--- a/documentation/docs/en/tools.md
+++ b/documentation/docs/en/tools.md
@@ -7,15 +7,15 @@ title: Built-in Tools
 
 Built-in tools let Sabiá models **search the web, run code, and query official Brazilian databases on the server side**, without you having to implement or host anything. Unlike [function calls](function-call.md) — which the model delegates back to *your* code — built-in tools run inside Maritaca's infrastructure as an agentic flow: the model decides which tools to call, calls them across multiple steps, and returns only the final answer. The intermediate reasoning and tool calls stay internal.
 
-Availability varies by tool: **web search** works on all Sabiá models, while **code execution** and **Data Ocean** are available only on **`sabia-4-thinking`**.
+Availability varies by tool: **web search** works on all Sabiá models, while **code execution** and **Data Ocean** are available on **`sabia-4`** and **`sabia-4-thinking`**.
 
 ## Available tools
 
 | Tool | Flag | Models | What it does |
 |---|---|---|---|
 | **Web search** | `web_search` | All Sabiá models | Searches the web and reads pages to answer with up-to-date information and sources. |
-| **Code execution** | `code_execution` | `sabia-4-thinking` only | Runs Python/Bash in a sandbox to compute, analyze data, and generate files (charts, documents). |
-| **Data Ocean** | `data_ocean` | `sabia-4-thinking` only | Queries dozens of official Brazilian databases — population, companies, health, climate, public safety, economy, elections, and more — to answer with real figures and sources. |
+| **Code execution** | `code_execution` | `sabia-4` and `sabia-4-thinking` | Runs Python/Bash in a sandbox to compute, analyze data, and generate files (charts, documents). |
+| **Data Ocean** | `data_ocean` | `sabia-4` and `sabia-4-thinking` | Queries dozens of official Brazilian databases — population, companies, health, climate, public safety, economy, elections, and more — to answer with real figures and sources. |
 
 :::info Data Ocean turns on the other tools automatically
 Enabling `data_ocean` also turns on **web search** (`web_search`) and **code execution** (`code_execution`) automatically. Data Ocean answers typically cross official data with web search and calculations. As a result, `data_ocean: true` can incur charges for **Data Ocean + web search + code execution** in the same request (see [Pricing](precos.md#built-in-tools)).
@@ -176,5 +176,5 @@ Built-in tool executions are billed per use, in addition to the usual token cost
 ## Notes and limitations
 
 - **Streaming is not supported** with built-in tools — send `stream: false`. A streaming request that enables a tool returns a `400` error.
-- **Availability depends on the tool**: web search (`web_search`) works on all Sabiá models; code execution (`code_execution`) and Data Ocean (`data_ocean`) work only on `sabia-4-thinking`. On incompatible models the flags are ignored.
+- **Availability depends on the tool**: web search (`web_search`) works on all Sabiá models; code execution (`code_execution`) and Data Ocean (`data_ocean`) work on `sabia-4` and `sabia-4-thinking`. On incompatible models the API returns a 400 error.
 - The agentic flow is **internal**: intermediate reasoning and tool calls are not exposed — only the final assistant message (plus any generated files) is returned.

--- a/documentation/docs/pt/ferramentas.md
+++ b/documentation/docs/pt/ferramentas.md
@@ -7,15 +7,15 @@ title: Ferramentas integradas
 
 As ferramentas integradas permitem que os modelos Sabiá **busquem na web, executem código e consultem bases de dados oficiais brasileiras no lado do servidor**, sem que você precise implementar ou hospedar nada. Diferentemente da [chamada de funções](chamada-funcao.md) — em que o modelo delega de volta para o *seu* código — as ferramentas integradas rodam dentro da infraestrutura da Maritaca como um fluxo agêntico: o modelo decide quais ferramentas chamar, as chama em múltiplos passos e retorna apenas a resposta final. O raciocínio e as chamadas de ferramenta intermediários ficam internos.
 
-A disponibilidade varia por ferramenta: a **Busca na web** funciona em todos os modelos Sabiá, enquanto a **Execução de código** e o **Data Ocean** estão disponíveis apenas no **`sabia-4-thinking`**.
+A disponibilidade varia por ferramenta: a **Busca na web** funciona em todos os modelos Sabiá, enquanto a **Execução de código** e o **Data Ocean** estão disponíveis nos modelos **`sabia-4`** e **`sabia-4-thinking`**.
 
 ## Ferramentas disponíveis
 
 | Ferramenta | Flag | Modelos | O que faz |
 |---|---|---|---|
 | **Busca na web** | `web_search` | Todos os modelos Sabiá | Pesquisa na web e lê páginas para responder com informações atualizadas e fontes. |
-| **Execução de código** | `code_execution` | Apenas `sabia-4-thinking` | Executa Python/Bash em um sandbox para calcular, analisar dados e gerar arquivos (gráficos, documentos). |
-| **Data Ocean** | `data_ocean` | Apenas `sabia-4-thinking` | Consulta dezenas de bases de dados oficiais brasileiras — população, empresas, saúde, clima, segurança, economia, eleições e mais — para responder com números e fontes reais. |
+| **Execução de código** | `code_execution` | `sabia-4` e `sabia-4-thinking` | Executa Python/Bash em um sandbox para calcular, analisar dados e gerar arquivos (gráficos, documentos). |
+| **Data Ocean** | `data_ocean` | `sabia-4` e `sabia-4-thinking` | Consulta dezenas de bases de dados oficiais brasileiras — população, empresas, saúde, clima, segurança, economia, eleições e mais — para responder com números e fontes reais. |
 
 :::info O Data Ocean liga as outras ferramentas automaticamente
 Ao ativar `data_ocean`, a **busca na web** (`web_search`) e a **execução de código** (`code_execution`) também são ativadas automaticamente. As respostas do Data Ocean costumam cruzar dados oficiais com busca na web e cálculos. Como consequência, `data_ocean: true` pode gerar cobranças de **Data Ocean + busca na web + execução de código** na mesma requisição (veja [Preços](precos.md#ferramentas-integradas)).
@@ -176,5 +176,5 @@ As execuções de ferramentas integradas são cobradas por uso, além dos custos
 ## Observações e limitações
 
 - **Streaming não é suportado** com ferramentas integradas — envie `stream: false`. Uma requisição em streaming que ative uma ferramenta retorna um erro `400`.
-- **A disponibilidade depende da ferramenta**: a Busca na web (`web_search`) funciona em todos os modelos Sabiá; a Execução de código (`code_execution`) e o Data Ocean (`data_ocean`) funcionam apenas no `sabia-4-thinking`. Em modelos incompatíveis, as flags são ignoradas.
+- **A disponibilidade depende da ferramenta**: a Busca na web (`web_search`) funciona em todos os modelos Sabiá; a Execução de código (`code_execution`) e o Data Ocean (`data_ocean`) funcionam nos modelos `sabia-4` e `sabia-4-thinking`. Em modelos incompatíveis, a API retorna erro 400.
 - O fluxo agêntico é **interno**: o raciocínio e as chamadas de ferramenta intermediários não são expostos — apenas a mensagem final do assistente (mais eventuais arquivos gerados) é retornada.


### PR DESCRIPTION
Acompanha a liberação no backend ([maritalk #1004](https://github.com/maritaca-ai/maritalk/pull/1004)): server tools deixam de ser exclusivas do `sabia-4-thinking`.

- **pt/ferramentas.md** e **en/tools.md**: disponibilidade atualizada nas 3 menções de cada página (`sabia-4` e `sabia-4-thinking`).
- Corrige também o comportamento documentado para modelos incompatíveis: a API retorna **erro 400** — os docs diziam que as flags eram ignoradas (desatualizado desde a #957).
- Exemplos de código mantidos com `sabia-4-thinking` (continuam válidos).

⚠️ Mergear junto/depois do deploy da maritalk #1004 — senão os docs prometem o que a API ainda barra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZzXRmrcC4e78wKwS6ji2