### PR TITLE
docs: atualiza integração do LangChain para Sabiá 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - [Exemplo de uso](#exemplo-de-uso)
 - [Exemplo de uso via requisições HTTP - JavaScript](https://docs.maritaca.ai/pt/exemplos/csharp-js)
 - [Exemplo de uso via requisições HTTP - C#](https://docs.maritaca.ai/pt/exemplos/csharp-js)
-- [Exemplo MariTalk + RAG com LangChain](https://python.langchain.com/docs/integrations/chat/maritalk)
+- [Exemplo LangChain com Sabiá 4 e tools](https://docs.maritaca.ai/pt/examples/langchain)
 - [Exemplo Maritalk no LlamaIndex](https://docs.llamaindex.ai/en/latest/examples/llm/maritalk)
 - [Documentação da API](https://docs.maritaca.ai)
 

--- a/documentation/docs/en/examples/langchain.md
+++ b/documentation/docs/en/examples/langchain.md
@@ -3,12 +3,124 @@ id: langchain
 title: LangChain
 ---
 
-This complete tutorial on MariTalk + LangChain covers a simple example, LLM+RAG with BM25, installation, API key usage, and streaming responses.
+The Maritaca API is compatible with the OpenAI Chat Completions API. In
+LangChain, use the `ChatOpenAI` class from the `langchain-openai` package and set
+Maritaca's endpoint as the `base_url`.
 
-<div style={{ display: 'flex', justifyContent: 'space-around', margin: '20px 0', flexWrap: 'wrap' }}>
-  <a href="https://python.langchain.com/docs/integrations/chat/maritalk/" className="icon-box" style={{ flex: '1 1 200px', margin: '10px', textAlign: 'center' }}>
-    <span className="geo-icon geo-icon-chain" aria-hidden="true"></span>
-    <h3>LangChain</h3>
-    <p>Maritaca + RAG with LangChain.</p>
-  </a>
-</div>
+:::note Migrating from the old integration
+
+The `ChatMaritalk` class from `langchain-community` is a legacy integration.
+Examples that use `sabia-2-small` or `sabia-2-medium` are also outdated because
+those models have been discontinued. Use `ChatOpenAI` with a current model as
+shown below.
+
+:::
+
+## Installation
+
+Install LangChain's OpenAI integration:
+
+```bash
+pip install -U langchain-openai
+```
+
+Set your API key in an environment variable. You can create a key in the
+[Maritaca platform](https://plataforma.maritaca.ai/chaves-de-api).
+
+```bash
+export MARITACA_API_KEY="your-key-here"
+```
+
+## Regular call
+
+```python
+import os
+
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="sabia-4",
+    api_key=os.environ["MARITACA_API_KEY"],
+    base_url="https://chat.maritaca.ai/api",
+)
+
+response = llm.invoke(
+    [
+        ("system", "Answer directly and briefly."),
+        ("human", "What is 25 + 27?"),
+    ]
+)
+
+print(response.content)
+```
+
+Both models use the same configuration:
+
+| Model | When to use it |
+|---|---|
+| `sabia-4` | General use with a good balance of quality, speed, and cost. |
+| `sabia-4-thinking` | Complex tasks that benefit from reasoning before the answer. |
+
+To use the reasoning model, change only the model name:
+
+```python
+llm = ChatOpenAI(
+    model="sabia-4-thinking",
+    api_key=os.environ["MARITACA_API_KEY"],
+    base_url="https://chat.maritaca.ai/api",
+)
+```
+
+## Tools (function calling)
+
+Use `bind_tools` to send tool definitions to the model. The model requests a
+tool call, but your application is responsible for executing it and returning
+the result in a `ToolMessage`.
+
+The example below forces the first tool call only to make the demonstration
+reproducible. In a regular application, omit `tool_choice` and let the model
+decide when to use the tool.
+
+```python
+import os
+
+from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+
+
+@tool
+def multiply(a: int, b: int) -> int:
+    """Multiply two integers."""
+    return a * b
+
+
+llm = ChatOpenAI(
+    model="sabia-4-thinking",
+    api_key=os.environ["MARITACA_API_KEY"],
+    base_url="https://chat.maritaca.ai/api",
+)
+
+question = "Use the multiply tool to calculate 6 times 7."
+messages = [HumanMessage(content=question)]
+
+llm_with_forced_tool = llm.bind_tools([multiply], tool_choice="multiply")
+tool_request = llm_with_forced_tool.invoke(messages)
+messages.append(tool_request)
+
+if not tool_request.tool_calls:
+    raise RuntimeError("The model did not request a tool")
+
+tool_call = tool_request.tool_calls[0]
+tool_result = multiply.invoke(tool_call["args"])
+messages.append(
+    ToolMessage(content=str(tool_result), tool_call_id=tool_call["id"])
+)
+
+final_response = llm.bind_tools([multiply]).invoke(messages)
+print(final_response.content)  # 42
+```
+
+This flow works with both `sabia-4` and `sabia-4-thinking`. For more information
+about messages, chains, and agents, see the
+[ChatOpenAI documentation](https://docs.langchain.com/oss/python/integrations/chat/openai).

--- a/documentation/docs/pt/examples/langchain.md
+++ b/documentation/docs/pt/examples/langchain.md
@@ -3,12 +3,124 @@ id: langchain
 title: LangChain
 ---
 
-Este tutorial completo sobre MariTalk + LangChain cobre um exemplo simples, LLM+RAG com BM25, instalação, uso de chave de API e streaming de respostas.
+A API da Maritaca é compatível com a API de Chat Completions da OpenAI. No
+LangChain, use a classe `ChatOpenAI` do pacote `langchain-openai` e configure o
+endpoint da Maritaca em `base_url`.
 
-<div style={{ display: 'flex', justifyContent: 'space-around', margin: '20px 0', flexWrap: 'wrap' }}>
-  <a href="https://python.langchain.com/docs/integrations/chat/maritalk/" className="icon-box" style={{ flex: '1 1 200px', margin: '10px', textAlign: 'center' }}>
-    <span className="geo-icon geo-icon-chain" aria-hidden="true"></span>
-    <h3>LangChain</h3>
-    <p>Maritaca + RAG com LangChain.</p>
-  </a>
-</div>
+:::note Migração da integração antiga
+
+A classe `ChatMaritalk`, disponível em `langchain-community`, é uma integração
+legada. Exemplos que usam `sabia-2-small` ou `sabia-2-medium` também estão
+desatualizados, pois esses modelos foram descontinuados. Use a configuração
+abaixo com `ChatOpenAI` e um modelo atual.
+
+:::
+
+## Instalação
+
+Instale a integração OpenAI do LangChain:
+
+```bash
+pip install -U langchain-openai
+```
+
+Defina sua chave em uma variável de ambiente. Você pode criar uma chave na
+[plataforma da Maritaca](https://plataforma.maritaca.ai/chaves-de-api).
+
+```bash
+export MARITACA_API_KEY="sua-chave-aqui"
+```
+
+## Chamada normal
+
+```python
+import os
+
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="sabia-4",
+    api_key=os.environ["MARITACA_API_KEY"],
+    base_url="https://chat.maritaca.ai/api",
+)
+
+response = llm.invoke(
+    [
+        ("system", "Responda de forma direta e curta."),
+        ("human", "Quanto é 25 + 27?"),
+    ]
+)
+
+print(response.content)
+```
+
+Os dois modelos podem ser usados com a mesma configuração:
+
+| Modelo | Quando usar |
+|---|---|
+| `sabia-4` | Uso geral, com bom equilíbrio entre qualidade, velocidade e custo. |
+| `sabia-4-thinking` | Tarefas complexas que se beneficiam de raciocínio antes da resposta. |
+
+Para usar o modelo de raciocínio, altere somente o nome do modelo:
+
+```python
+llm = ChatOpenAI(
+    model="sabia-4-thinking",
+    api_key=os.environ["MARITACA_API_KEY"],
+    base_url="https://chat.maritaca.ai/api",
+)
+```
+
+## Tools (function calling)
+
+Use `bind_tools` para enviar a definição das ferramentas ao modelo. O modelo
+solicita a chamada, mas sua aplicação é responsável por executá-la e devolver o
+resultado em uma `ToolMessage`.
+
+O exemplo abaixo força a primeira chamada da ferramenta apenas para tornar a
+demonstração reproduzível. Em uma aplicação normal, omita `tool_choice` para o
+modelo decidir quando usar a ferramenta.
+
+```python
+import os
+
+from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+
+
+@tool
+def multiply(a: int, b: int) -> int:
+    """Multiplica dois números inteiros."""
+    return a * b
+
+
+llm = ChatOpenAI(
+    model="sabia-4-thinking",
+    api_key=os.environ["MARITACA_API_KEY"],
+    base_url="https://chat.maritaca.ai/api",
+)
+
+question = "Use a ferramenta multiply para calcular 6 vezes 7."
+messages = [HumanMessage(content=question)]
+
+llm_with_forced_tool = llm.bind_tools([multiply], tool_choice="multiply")
+tool_request = llm_with_forced_tool.invoke(messages)
+messages.append(tool_request)
+
+if not tool_request.tool_calls:
+    raise RuntimeError("O modelo não solicitou uma ferramenta")
+
+tool_call = tool_request.tool_calls[0]
+tool_result = multiply.invoke(tool_call["args"])
+messages.append(
+    ToolMessage(content=str(tool_result), tool_call_id=tool_call["id"])
+)
+
+final_response = llm.bind_tools([multiply]).invoke(messages)
+print(final_response.content)  # 42
+```
+
+Esse fluxo funciona tanto com `sabia-4` quanto com `sabia-4-thinking`. Para mais
+detalhes sobre mensagens, chains e agentes, consulte a
+[documentação do ChatOpenAI](https://docs.langchain.com/oss/python/integrations/chat/openai).


### PR DESCRIPTION
## Contexto

A página de LangChain redirecionava para um exemplo legado baseado em `ChatMaritalk` e `sabia-2-medium`. O modelo está descontinuado e a integração antiga não cobre tool calling.

## Mudanças

- substitui o redirecionamento por guias completos em português e inglês
- usa `ChatOpenAI` de `langchain-openai` com o endpoint compatível da Maritaca
- documenta chamadas normais com `sabia-4` e `sabia-4-thinking`
- adiciona um ciclo completo de tool calling com `bind_tools`, execução local e `ToolMessage`
- explica a migração da integração legada
- aponta o README para o guia mantido neste repositório

## Validação

- `langchain-openai 1.3.5`, `langchain-core 1.4.9` e `openai 2.46.0`
- chamada normal live: `sabia-4` e `sabia-4-thinking`
- tool calling live: solicitação estruturada, execução e resposta final nos dois modelos
- todos os blocos Python das páginas PT e EN extraídos e executados diretamente
- 11 testes de desenvolvimento passaram: 7 documentais e 4 integrações live
- `npm ci && npm run build` passou para as locales PT e EN
- `git diff --check` e varredura de segredos passaram

## Curadoria dos testes

Os testes temporários live e documentais foram removidos do diff final. Os testes live exigem uma chave paga e dependências LangChain opcionais que o projeto não declara; os testes estáticos duplicavam literalmente o conteúdo das páginas e o repositório não possui esse runner no CI. O build Docusaurus foi mantido como a validação estrutural existente.