### PR TITLE
docs: atualiza exemplos de integrações com Sabiá 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 - [Compatibilidade com API da Open AI](#a-api-da-maritalk-é-compatível-com-a-api-da-open-ai)
 - [Instalação](#instalação)
 - [Exemplo de uso](#exemplo-de-uso)
-- [Exemplo de uso via requisições HTTP - JavaScript](https://docs.maritaca.ai/pt/exemplos/csharp-js)
-- [Exemplo de uso via requisições HTTP - C#](https://docs.maritaca.ai/pt/exemplos/csharp-js)
+- [Exemplo de uso em JavaScript](https://docs.maritaca.ai/pt/examples/csharp-js)
+- [Exemplo de uso em C#](https://docs.maritaca.ai/pt/examples/csharp-js)
 - [Exemplo LangChain com Sabiá 4 e tools](https://docs.maritaca.ai/pt/examples/langchain)
-- [Exemplo Maritalk no LlamaIndex](https://docs.llamaindex.ai/en/latest/examples/llm/maritalk)
+- [Exemplo Maritaca no LlamaIndex](https://docs.maritaca.ai/pt/examples/llama-index)
 - [Documentação da API](https://docs.maritaca.ai)
 
 [MariTalk Local](https://github.com/maritaca-ai/maritalk-api/blob/main/README-Local.md)

--- a/documentation/docs/en/examples/csharp-js.md
+++ b/documentation/docs/en/examples/csharp-js.md
@@ -1,205 +1,179 @@
 ---
 id: csharp-js
-title: C#
+title: C# and JavaScript
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Usage Examples in C# and JavaScript
+The examples below use the official OpenAI SDKs with Maritaca's compatible
+endpoint. Both make a regular call and complete a full tool-calling cycle.
 
-Here are examples of how you can integrate the Maritaca API in C# and JavaScript:
+Set the API key before running the examples. The default model is `sabia-4`; set
+`MARITACA_MODEL=sabia-4-thinking` to use the reasoning model.
 
+```bash
+export MARITACA_API_KEY="your-key-here"
+export MARITACA_MODEL="sabia-4"
+```
 
 <Tabs>
 <TabItem value="JavaScript" label="JavaScript" default>
-```javascript
-const process = require('node:process');
 
-const RESPONSES_API_URL = "https://chat.maritaca.ai/api/v1/responses";
+Install the SDK and save the example as `example.mjs`:
 
-if (!process.env.MARITACA_API_KEY) {
-    console.error("Environment variable MARITACA_API_KEY not found!");
-    process.exit(1);
-}
-
-async function sendRequest(message) {
-    try {
-        const params = {
-            model: "sabia-4",
-            input: message,
-            max_output_tokens: 50,
-            temperature: 0.4,
-            top_p: 0.95,
-        };
-
-        const response = await fetch(RESPONSES_API_URL, {
-            headers: {
-                "Authorization": `Bearer ${process.env.MARITACA_API_KEY}`,
-                "Content-Type": "application/json",
-            },
-            method: "POST",
-            body: JSON.stringify(params),
-        });
-
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        return await response.json();
-    } catch (error) {
-        console.error("Error sending request:", error);
-        throw error;
-    }
-}
-
-async function main() {
-    try {
-        const result = await sendRequest('Hello, what is your name?');
-        console.log("Response:", result.output[0].content[0].text);
-    } catch (error) {
-        console.error("Error in main function:", error);
-    }
-}
-
-main();
+```bash
+npm install openai
+node example.mjs
 ```
+
+```javascript
+import OpenAI from "openai";
+
+const apiKey = process.env.MARITACA_API_KEY;
+if (!apiKey) throw new Error("Set MARITACA_API_KEY");
+
+const model = process.env.MARITACA_MODEL ?? "sabia-4";
+const client = new OpenAI({
+  apiKey,
+  baseURL: "https://chat.maritaca.ai/api",
+});
+
+const normal = await client.chat.completions.create({
+  model,
+  messages: [{ role: "user", content: "What is 25 + 27? Include 52 in the answer." }],
+});
+const normalText = normal.choices[0].message.content;
+console.log("Regular call:", normalText);
+
+const multiplyTool = {
+  type: "function",
+  function: {
+    name: "multiply",
+    description: "Multiply two integers.",
+    parameters: {
+      type: "object",
+      properties: {
+        a: { type: "integer" },
+        b: { type: "integer" },
+      },
+      required: ["a", "b"],
+      additionalProperties: false,
+    },
+  },
+};
+
+const messages = [
+  { role: "user", content: "Use multiply to calculate 6 times 7." },
+];
+const toolRequest = await client.chat.completions.create({
+  model,
+  messages,
+  tools: [multiplyTool],
+  tool_choice: { type: "function", function: { name: "multiply" } },
+});
+
+const assistantMessage = toolRequest.choices[0].message;
+const toolCall = assistantMessage.tool_calls?.[0];
+if (!toolCall) throw new Error("The model did not request a tool");
+
+const { a, b } = JSON.parse(toolCall.function.arguments);
+messages.push(
+  assistantMessage,
+  { role: "tool", tool_call_id: toolCall.id, content: String(a * b) },
+);
+
+const final = await client.chat.completions.create({
+  model,
+  messages,
+  tools: [multiplyTool],
+});
+console.log("Tool response:", final.choices[0].message.content); // 42
+```
+
 </TabItem>
 <TabItem value="C#" label="C#">
+
+Create a .NET 8 or newer project, install the SDK, and replace `Program.cs` with
+the example:
+
+```bash
+dotnet new console -n MaritacaExample
+cd MaritacaExample
+dotnet add package OpenAI
+dotnet run
+```
+
 ```csharp
+using System.ClientModel;
+using System.Text.Json;
 using OpenAI;
 using OpenAI.Chat;
-using System.ClientModel;
 
-namespace ChatMaritaca
-{
-    class Program
+static int Multiply(int a, int b) => a * b;
+
+string apiKey = Environment.GetEnvironmentVariable("MARITACA_API_KEY")
+    ?? throw new InvalidOperationException("MARITACA_API_KEY is required.");
+string model = Environment.GetEnvironmentVariable("MARITACA_MODEL") ?? "sabia-4";
+
+ChatClient client = new ChatClient(
+    model: model,
+    credential: new ApiKeyCredential(apiKey),
+    options: new OpenAIClientOptions
     {
-        static async Task Main(string[] args)
+        Endpoint = new Uri("https://chat.maritaca.ai/api")
+    });
+
+ChatCompletion normal = await client.CompleteChatAsync(
+    "What is 25 + 27? Include 52 in the answer.");
+string normalText = normal.Content[0].Text;
+Console.WriteLine($"Regular call: {normalText}");
+
+ChatTool multiplyTool = ChatTool.CreateFunctionTool(
+    functionName: nameof(Multiply),
+    functionDescription: "Multiply two integers.",
+    functionParameters: BinaryData.FromBytes("""
         {
-            //variables
-            string key = "";
-            string model = "sabiazinho-4";
-            string url = "https://chat.maritaca.ai/api";
-            string nameProject = "ExemploUsandoMaritaca";
-
-            //Create the credential using the API access key
-            ApiKeyCredential apiKeyCredential = new ApiKeyCredential(key);
-
-            //Configure the Client for the Maritaca endpoint
-            OpenAIClientOptions openAIClientOptions = new OpenAIClientOptions
-            {
-                Endpoint = new Uri(url),
-                OrganizationId = nameProject,
-                ApplicationId = nameProject,
-                ProjectId = nameProject
-            };
-
-            //Create the ChatClient
-            ChatClient chatClient = new ChatClient(model, apiKeyCredential, openAIClientOptions);
-
-            //Create the chat options
-            ChatCompletionOptions chatOptions = new ChatCompletionOptions
-            {
-                MaxTokens = 255,
-                Temperature = 0.7f,
-            };
-
-            //Create a list to store the chat messages
-            List<ChatMessage> chatMessages = new List<ChatMessage>();
-
-            //Show the menu
-            ShowMenu();
-            do
-            {
-                try
-                {
-                    //User question
-                    string prompt = ShowPrompt();
-
-                    //If the user types 'sair', the chat ends
-                    if (prompt.ToLower() == "sair")
-                        break;
-
-                    //Create the user message
-                    UserChatMessage userChat = ChatMessage.CreateUserMessage(prompt);
-                    chatMessages.Add(userChat);
-
-                    //Send the question to the API
-                    ChatCompletion chatCompletion = await chatClient.CompleteChatAsync(chatMessages, chatOptions);
-
-                    //Capture the response from the model
-                    AssistantChatMessage assistant = ChatMessage.CreateAssistantMessage(chatCompletion.Content[0].Text);
-                    chatMessages.Add(assistant);
-
-                    //Display the model's response
-                    ShowAssistant(assistant);
-                }
-                catch (Exception e)
-                {
-                    ShowError(e);
-                }
-            } while (true);
-
-            ShowSair();
+          "type": "object",
+          "properties": {
+            "a": { "type": "integer" },
+            "b": { "type": "integer" }
+          },
+          "required": ["a", "b"],
+          "additionalProperties": false
         }
+        """u8.ToArray()));
 
-        static void ShowMenu()
-        {
-            Console.WriteLine(new string('-', 100));
-            Console.WriteLine();
-            Console.WriteLine("Welcome to Maritaca Chat!");
-            Console.WriteLine();
-            Console.WriteLine(new string('-', 100));
-            Console.WriteLine("Type 'exit' to end the chat.");
-            Console.WriteLine();
-            Console.WriteLine();
-            Console.WriteLine();
-        }
+List<ChatMessage> messages =
+[
+    new UserChatMessage("Use Multiply to calculate 6 times 7.")
+];
+ChatCompletionOptions options = new()
+{
+    ToolChoice = ChatToolChoice.CreateFunctionChoice(nameof(Multiply))
+};
+options.Tools.Add(multiplyTool);
 
-        static string ShowPrompt()
-        {
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.Write($"[{DateTime.Now}] Send a message: ");
-            Console.ResetColor();
-            string prompt = Console.ReadLine();
-            if (string.IsNullOrEmpty(prompt))
-            {
-                throw new Exception("Please enter a message.");
-            }
-            return prompt;
-        }
+ChatCompletion toolRequest = await client.CompleteChatAsync(messages, options);
+if (toolRequest.ToolCalls.Count == 0)
+    throw new InvalidOperationException("The model did not request a tool.");
 
-        static void ShowAssistant(AssistantChatMessage assistant)
-        {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine();
-            Console.Write($"[{DateTime.Now}] Assistente: ");
-            Console.ResetColor();
-            Console.WriteLine(assistant.Content[0].Text);
-            Console.WriteLine();
-        }
+messages.Add(new AssistantChatMessage(toolRequest));
+ChatToolCall toolCall = toolRequest.ToolCalls[0];
+using JsonDocument arguments = JsonDocument.Parse(toolCall.FunctionArguments);
+int result = Multiply(
+    arguments.RootElement.GetProperty("a").GetInt32(),
+    arguments.RootElement.GetProperty("b").GetInt32());
+messages.Add(new ToolChatMessage(toolCall.Id, result.ToString()));
 
-        static void ShowError(Exception e)
-        {
-            Console.WriteLine();
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.Write($"[{DateTime.Now}] Erro: ");
-            Console.ResetColor();
-            Console.WriteLine(e.Message);
-            Console.WriteLine();
-        }
-
-        static void ShowSair()
-        {
-            Console.WriteLine(new string('-', 100));
-            Console.WriteLine();
-            Console.WriteLine("Thanks for using Maritaca Chat!");
-            Console.WriteLine();
-            Console.WriteLine();
-        }
-    }
-}
+options.ToolChoice = ChatToolChoice.CreateAutoChoice();
+ChatCompletion final = await client.CompleteChatAsync(messages, options);
+Console.WriteLine($"Tool response: {final.Content[0].Text}"); // 42
 ```
+
 </TabItem>
 </Tabs>
+
+Do not rely on `FinishReason` alone to detect a tool request: check whether
+`ToolCalls` contains items. The same flow works with `sabia-4` and
+`sabia-4-thinking`.

--- a/documentation/docs/en/examples/langgraph.md
+++ b/documentation/docs/en/examples/langgraph.md
@@ -1,42 +1,64 @@
 ---
 id: langgraph
-title: Langgraph
+title: LangGraph
 ---
 
+LangChain's `create_agent` creates a LangGraph-based agent. You can use the
+Maritaca API through `ChatOpenAI` by configuring Maritaca's endpoint as the
+`base_url`.
 
-## LangGraph + ReAct
+## Installation
 
-Maritaca models work with LangGraph via the OpenAI SDK. Configure base_url, api_key, and model. ReAct agent example with one tool:
+```bash
+pip install -U langchain langchain-openai langgraph
+export MARITACA_API_KEY="your-key-here"
+```
+
+The example uses `sabia-4` by default. To use the reasoning model, set
+`MARITACA_MODEL=sabia-4-thinking`.
+
+## Regular call and agent with a tool
 
 ```python
-# pip install -U langchain-openai langgraph langchain-core
 import os
-from langchain_openai import ChatOpenAI
-from langgraph.prebuilt import create_react_agent
-from langchain_core.messages import HumanMessage
 
+from langchain.agents import create_agent
+from langchain.tools import tool
+from langchain_openai import ChatOpenAI
+
+
+model_name = os.getenv("MARITACA_MODEL", "sabia-4")
 llm = ChatOpenAI(
-    model="sabiazinho-3",
-    api_key=os.environ.get("MARITACA_API_KEY"),
+    model=model_name,
+    api_key=os.environ["MARITACA_API_KEY"],
     base_url="https://chat.maritaca.ai/api",
 )
 
-def add(a: int, b: int) -> int:
-    """Sum a and b.
+normal_response = llm.invoke("What is 25 + 27? Include 52 in the answer.")
+print("Regular call:", normal_response.content)
 
-    Args:
-        a: first integer
-        b: second integer
-    """
+
+@tool
+def add(a: int, b: int) -> int:
+    """Add two integers."""
     return a + b
 
-tools = [add]
-react_graph = create_react_agent(llm, tools=tools)
-messages = [HumanMessage(content="Add 12 and 3.")]
-state = react_graph.invoke({"messages": messages})
 
-for m in state["messages"]:
-    m.pretty_print()
+agent = create_agent(
+    model=llm,
+    tools=[add],
+    system_prompt="Always use the add tool for addition.",
+)
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "Use add to calculate 12 + 3."}]}
+)
 
+print("Agent:", result["messages"][-1].content)  # 15
+```
 
+The same code works with `sabia-4` and `sabia-4-thinking`. The agent executes
+the tool locally and adds its result to the message history before requesting
+the final answer from the model.
 
+For more information, see the
+[LangChain agents documentation](https://docs.langchain.com/oss/python/langchain/agents).

--- a/documentation/docs/en/examples/llama-index.md
+++ b/documentation/docs/en/examples/llama-index.md
@@ -1,14 +1,84 @@
 ---
 id: llama-index
-title: Llama-index
+title: LlamaIndex
 ---
 
-This MariTalk + LlamaIndex tutorial covers installation, API key setup, chat for name suggestions, few-shot with complete for review classification, and synchronous and asynchronous streaming.
+Use LlamaIndex's `OpenAILike` integration to connect OpenAI-compatible models to
+a custom endpoint.
 
-<div style={{ display: 'flex', justifyContent: 'space-around', margin: '20px 0', flexWrap: 'wrap' }}>
-  <a href="https://docs.llamaindex.ai/en/latest/examples/llm/maritalk/" className="icon-box" style={{ flex: '1 1 200px', margin: '10px', textAlign: 'center' }}>
-    <span className="geo-icon geo-icon-graph" aria-hidden="true"></span>
-    <h3>LlamaIndex</h3>
-    <p>Maritaca no LlamaIndex.</p>
-  </a>
-</div>
+## Installation
+
+```bash
+pip install -U llama-index-core llama-index-llms-openai-like
+export MARITACA_API_KEY="your-key-here"
+```
+
+The example uses `sabia-4` by default. To use the reasoning model, set
+`MARITACA_MODEL=sabia-4-thinking`.
+
+## Regular call and tools
+
+```python
+import json
+import os
+
+from llama_index.core.llms import ChatMessage
+from llama_index.core.tools import FunctionTool
+from llama_index.llms.openai_like import OpenAILike
+
+
+model_name = os.getenv("MARITACA_MODEL", "sabia-4")
+llm = OpenAILike(
+    model=model_name,
+    api_key=os.environ["MARITACA_API_KEY"],
+    api_base="https://chat.maritaca.ai/api",
+    context_window=128_000,
+    is_chat_model=True,
+    is_function_calling_model=True,
+)
+
+normal_response = llm.chat(
+    [ChatMessage(role="user", content="What is 25 + 27? Include 52 in the answer.")]
+)
+print("Regular call:", normal_response)
+
+
+def multiply(a: int, b: int) -> int:
+    """Multiply two integers."""
+    return a * b
+
+
+tool = FunctionTool.from_defaults(fn=multiply)
+tool_spec = tool.metadata.to_openai_tool()
+messages = [
+    ChatMessage(role="user", content="Use multiply to calculate 6 times 7.")
+]
+
+tool_request = llm.chat(
+    messages,
+    tools=[tool_spec],
+    tool_choice={"type": "function", "function": {"name": "multiply"}},
+)
+tool_calls = tool_request.message.additional_kwargs.get("tool_calls", [])
+if not tool_calls:
+    raise RuntimeError("The model did not request a tool")
+
+tool_call = tool_calls[0]
+tool_result = tool(**json.loads(tool_call.function.arguments))
+messages.extend(
+    [
+        tool_request.message,
+        ChatMessage(role="tool", content=str(tool_result), additional_kwargs={"tool_call_id": tool_call.id}),
+    ]
+)
+
+final_response = llm.chat(messages, tools=[tool_spec])
+print("Tool response:", final_response)  # 42
+```
+
+This tool loop only uses public LlamaIndex APIs and works with `sabia-4` and
+`sabia-4-thinking`. Your application receives the structured request, executes
+the function, and returns its result with the same `tool_call_id`.
+
+For more information, see the
+[OpenAILike documentation](https://docs.llamaindex.ai/en/stable/api_reference/llms/openai_like/).

--- a/documentation/docs/en/examples/n8n.md
+++ b/documentation/docs/en/examples/n8n.md
@@ -3,103 +3,94 @@ id: n8n
 title: n8n
 ---
 
-## Maritaca AI + n8n
+[n8n](https://n8n.io) can use Maritaca models through the **OpenAI Chat Model**
+sub-node. The configuration below was validated on n8n 2.30.7 with both a
+simple chain and an agent that executes a tool.
 
-[n8n](https://n8n.io) is a workflow automation platform that connects various applications and services. Since the Maritaca API is OpenAI-compatible, you can use n8n's **OpenAI Chat Model** node to integrate Sabiá models (e.g., Sabiá-4) into your workflows.
+## Prerequisites
 
-### Prerequisites
+- An n8n Cloud or self-hosted instance.
+- A key created in the
+  [Maritaca platform](https://plataforma.maritaca.ai/chaves-de-api).
 
-- An n8n instance (self-hosted or n8n Cloud)
-- A Maritaca API key ([get one here](https://chat.maritaca.ai))
+Keep the `MARITACA_API_KEY` value outside the workflow and only store it in an
+n8n credential.
 
-### Step 1: Create the credential
+## Create the credential
 
-1. In n8n, go to **Settings** > **Credentials** > **Add Credential**
-2. Search for **OpenAI** and select it
-3. Fill in the fields:
-   - **API Key:** your Maritaca API key
-   - **Base URL:** `https://chat.maritaca.ai/api`
-4. Give it a descriptive name, such as **"Maritaca AI"**
-5. Click **Save**
+1. Go to **Settings** > **Credentials** > **Add Credential**.
+2. Search for **OpenAI**.
+3. In **API Key**, paste the value of your `MARITACA_API_KEY`.
+4. Set **Base URL** to `https://chat.maritaca.ai/api`.
+5. Save it with a name such as **Maritaca AI**.
 
-:::info
-The "Test" button may show a warning, as n8n tries to validate using OpenAI-specific endpoints. This does not affect functionality — proceed normally.
-:::
+## Configure OpenAI Chat Model
 
-### Step 2: Configure the model in a workflow
+Add **OpenAI Chat Model** to the chain or agent's **Chat Model** slot and set:
 
-1. Create a new workflow and add a root node — **AI Agent** (for workflows with tools) or **Basic LLM Chain** (for simple calls)
-2. Click the **"+"** on the root node's **Chat Model** slot
-3. Select **OpenAI Chat Model**
-4. Configure:
-   - **Credential:** select the "Maritaca AI" credential created in Step 1
-   - **Model:** type `sabia-4` manually (use expression mode if the dropdown doesn't list the model)
+- **Credential:** `Maritaca AI`.
+- **Model:** select **ID** mode and enter `sabia-4` or
+  `sabia-4-thinking`.
+- **Use Responses API:** disabled.
 
-:::tip
-If the model dropdown doesn't populate, click the expression icon next to the field and type the model name directly: `sabia-4`.
-:::
+Disabling **Use Responses API** makes the sub-node use Chat Completions, which
+is the flow validated in the examples below.
 
-### Example 1: Simple chatbot
+## Regular call with Basic LLM Chain
 
-Build the following workflow:
+Build this workflow:
 
-```
-Chat Trigger → Basic LLM Chain → (output)
-                     │
-               OpenAI Chat Model
-               (credential: Maritaca AI)
-               (model: sabia-4)
+```text
+Manual Trigger → Basic LLM Chain
+                       │
+                OpenAI Chat Model
 ```
 
-**Steps:**
-1. Add a **Chat Trigger** node (provides the chat UI for testing)
-2. Add a **Basic LLM Chain** node and connect it to the Chat Trigger
-3. Attach the **OpenAI Chat Model** sub-node to the Basic LLM Chain (via the Chat Model slot)
-4. Select the Maritaca AI credential and model `sabia-4`
-5. Click **Chat** at the bottom of the canvas to test
+1. In **Basic LLM Chain**, select **Define below** for the prompt.
+2. Enter `What is 25 + 27? Include 52 in the answer.`.
+3. Connect the configured **OpenAI Chat Model**.
+4. Execute the workflow and inspect the chain output.
 
-### Example 2: Agent with tools
+## Agent with Calculator
 
-```
-Chat Trigger → AI Agent → (output)
-                  │
-            OpenAI Chat Model  +  Tool nodes  +  Memory
-            (credential: Maritaca AI)
-            (model: sabia-4)
+Build this workflow:
+
+```text
+Manual Trigger → AI Agent
+                    ├── OpenAI Chat Model
+                    └── Calculator
 ```
 
-**Steps:**
-1. Add a **Chat Trigger** node
-2. Add an **AI Agent** node and connect it to the trigger
-3. Attach the **OpenAI Chat Model** sub-node with the Maritaca AI credential
-4. Add **Tool** sub-nodes as needed (HTTP Request Tool, Calculator, Code Tool, etc.)
-5. Optionally add a **Memory** sub-node (e.g., Window Buffer Memory) for conversation history
+1. In **AI Agent**, select **Define below** for the prompt.
+2. Enter `Use the Calculator tool to calculate 6 times 7.`.
+3. Connect **OpenAI Chat Model** to the **Chat Model** slot.
+4. Add **Calculator** to the **Tool** slot.
+5. Execute the workflow; the final answer should include `42`.
 
-### Example 3: Direct HTTP call (alternative)
+## HTTP Request alternative
 
-For full control over the request, use the **HTTP Request** node:
+For a direct request, configure an **HTTP Request** node:
 
-1. Add an **HTTP Request** node
-2. Configure:
-   - **Method:** POST
-   - **URL:** `https://chat.maritaca.ai/api/chat/completions`
-   - **Authentication:** Header Auth
-   - **Header Name:** `Authorization`
-   - **Header Value:** `Bearer YOUR_API_KEY`
-   - **Body (JSON):**
+- **Method:** `POST`.
+- **URL:** `https://chat.maritaca.ai/api/chat/completions`.
+- **Authentication:** `Header Auth`.
+- **Header Name:** `Authorization`.
+- **Header Value:** `Bearer YOUR_API_KEY`.
+- **Content-Type:** `application/json`.
+- **Body:**
 
 ```json
 {
   "model": "sabia-4",
   "messages": [
-    {"role": "user", "content": "Explain what artificial intelligence is."}
+    {
+      "role": "user",
+      "content": "What is 25 + 27? Include 52 in the answer."
+    }
   ],
-  "max_tokens": 1024
+  "max_tokens": 100
 }
 ```
 
-### Tips
-
-- **Available models:** `sabia-4`, `sabiazinho-4`, `sabia-3.1`, `sabia-3`, `sabiazinho-3`
-- **Function calling:** Sabiá-4 supports OpenAI-format function calling, compatible with n8n's AI Agent node
-- **Docker:** if n8n runs in Docker and the API is local, use the host machine's IP or `host.docker.internal` instead of `localhost`
+To use the reasoning model, only change `model` to `sabia-4-thinking`. Do not
+put the API key directly in the workflow JSON.

--- a/documentation/docs/pt/examples/csharp-js.md
+++ b/documentation/docs/pt/examples/csharp-js.md
@@ -2,202 +2,178 @@
 id: csharp-js
 title: C# e JavaScript
 ---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+Os exemplos abaixo usam as SDKs oficiais da OpenAI com o endpoint compatível da
+Maritaca. Ambos fazem uma chamada normal e um ciclo completo de tool calling.
 
-# Exemplos de Uso em C# e em JavaScript
-Aqui estão exemplos de como você pode integrar a API da Maritaca em C# e em JavaScript:
+Defina a chave antes de executar. O modelo padrão é `sabia-4`; para usar o
+modelo de raciocínio, defina `MARITACA_MODEL=sabia-4-thinking`.
+
+```bash
+export MARITACA_API_KEY="sua-chave-aqui"
+export MARITACA_MODEL="sabia-4"
+```
 
 <Tabs>
 <TabItem value="JavaScript" label="JavaScript" default>
-```javascript
-const process = require('node:process');
 
-const RESPONSES_API_URL = "https://chat.maritaca.ai/api/v1/responses";
+Instale a SDK e salve o exemplo como `example.mjs`:
 
-if (!process.env.MARITACA_API_KEY) {
-    console.error("Variável de ambiente MARITACA_API_KEY não encontrada!");
-    process.exit(1);
-}
-
-async function sendRequest(message) {
-    try {
-        const params = {
-            model: "sabia-4",
-            input: message,
-            max_output_tokens: 50,
-            temperature: 0.4,
-            top_p: 0.95,
-        };
-
-        const response = await fetch(RESPONSES_API_URL, {
-            headers: {
-                "Authorization": `Bearer ${process.env.MARITACA_API_KEY}`,
-                "Content-Type": "application/json",
-            },
-            method: "POST",
-            body: JSON.stringify(params),
-        });
-
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        return await response.json();
-    } catch (error) {
-        console.error("Erro ao enviar requisição:", error);
-        throw error;
-    }
-}
-
-async function main() {
-    try {
-        const result = await sendRequest('Olá, qual é seu nome?');
-        console.log("Resposta:", result.output[0].content[0].text);
-    } catch (error) {
-        console.error("Erro na função main:", error);
-    }
-}
-
-main();
+```bash
+npm install openai
+node example.mjs
 ```
+
+```javascript
+import OpenAI from "openai";
+
+const apiKey = process.env.MARITACA_API_KEY;
+if (!apiKey) throw new Error("Defina MARITACA_API_KEY");
+
+const model = process.env.MARITACA_MODEL ?? "sabia-4";
+const client = new OpenAI({
+  apiKey,
+  baseURL: "https://chat.maritaca.ai/api",
+});
+
+const normal = await client.chat.completions.create({
+  model,
+  messages: [{ role: "user", content: "Quanto é 25 + 27? Inclua 52 na resposta." }],
+});
+const normalText = normal.choices[0].message.content;
+console.log("Chamada normal:", normalText);
+
+const multiplyTool = {
+  type: "function",
+  function: {
+    name: "multiply",
+    description: "Multiplica dois números inteiros.",
+    parameters: {
+      type: "object",
+      properties: {
+        a: { type: "integer" },
+        b: { type: "integer" },
+      },
+      required: ["a", "b"],
+      additionalProperties: false,
+    },
+  },
+};
+
+const messages = [
+  { role: "user", content: "Use multiply para calcular 6 vezes 7." },
+];
+const toolRequest = await client.chat.completions.create({
+  model,
+  messages,
+  tools: [multiplyTool],
+  tool_choice: { type: "function", function: { name: "multiply" } },
+});
+
+const assistantMessage = toolRequest.choices[0].message;
+const toolCall = assistantMessage.tool_calls?.[0];
+if (!toolCall) throw new Error("O modelo não solicitou uma ferramenta");
+
+const { a, b } = JSON.parse(toolCall.function.arguments);
+messages.push(
+  assistantMessage,
+  { role: "tool", tool_call_id: toolCall.id, content: String(a * b) },
+);
+
+const final = await client.chat.completions.create({
+  model,
+  messages,
+  tools: [multiplyTool],
+});
+console.log("Resposta com tool:", final.choices[0].message.content); // 42
+```
+
 </TabItem>
 <TabItem value="C#" label="C#">
+
+Crie um projeto .NET 8 ou mais recente, instale a SDK e substitua o conteúdo de
+`Program.cs` pelo exemplo:
+
+```bash
+dotnet new console -n MaritacaExample
+cd MaritacaExample
+dotnet add package OpenAI
+dotnet run
+```
+
 ```csharp
+using System.ClientModel;
+using System.Text.Json;
 using OpenAI;
 using OpenAI.Chat;
-using System.ClientModel;
 
-namespace ChatMaritaca
-{
-    class Program
+static int Multiply(int a, int b) => a * b;
+
+string apiKey = Environment.GetEnvironmentVariable("MARITACA_API_KEY")
+    ?? throw new InvalidOperationException("MARITACA_API_KEY é obrigatória.");
+string model = Environment.GetEnvironmentVariable("MARITACA_MODEL") ?? "sabia-4";
+
+ChatClient client = new ChatClient(
+    model: model,
+    credential: new ApiKeyCredential(apiKey),
+    options: new OpenAIClientOptions
     {
-        static async Task Main(string[] args)
+        Endpoint = new Uri("https://chat.maritaca.ai/api")
+    });
+
+ChatCompletion normal = await client.CompleteChatAsync(
+    "Quanto é 25 + 27? Inclua 52 na resposta.");
+string normalText = normal.Content[0].Text;
+Console.WriteLine($"Chamada normal: {normalText}");
+
+ChatTool multiplyTool = ChatTool.CreateFunctionTool(
+    functionName: nameof(Multiply),
+    functionDescription: "Multiplica dois números inteiros.",
+    functionParameters: BinaryData.FromBytes("""
         {
-            //variables
-            string key = "";
-            string model = "sabiazinho-4";
-            string url = "https://chat.maritaca.ai/api";
-            string nameProject = "ExemploUsandoMaritaca";
-
-            //Create the credential using the API access key
-            ApiKeyCredential apiKeyCredential = new ApiKeyCredential(key);
-
-            //Configure the Client for the Maritaca endpoint
-            OpenAIClientOptions openAIClientOptions = new OpenAIClientOptions
-            {
-                Endpoint = new Uri(url),
-                OrganizationId = nameProject,
-                ApplicationId = nameProject,
-                ProjectId = nameProject
-            };
-
-            //Create the ChatClient
-            ChatClient chatClient = new ChatClient(model, apiKeyCredential, openAIClientOptions);
-
-            //Create the chat options
-            ChatCompletionOptions chatOptions = new ChatCompletionOptions
-            {
-                MaxTokens = 255,
-                Temperature = 0.7f,
-            };
-
-            //Create a list to store the chat messages
-            List<ChatMessage> chatMessages = new List<ChatMessage>();
-
-            //Show the menu
-            ShowMenu();
-            do
-            {
-                try
-                {
-                    //User question
-                    string prompt = ShowPrompt();
-
-                    //If the user types 'sair', the chat ends
-                    if (prompt.ToLower() == "sair")
-                        break;
-
-                    //Create the user message
-                    UserChatMessage userChat = ChatMessage.CreateUserMessage(prompt);
-                    chatMessages.Add(userChat);
-
-                    //Send the question to the API
-                    ChatCompletion chatCompletion = await chatClient.CompleteChatAsync(chatMessages, chatOptions);
-
-                    //Capture the response from the model
-                    AssistantChatMessage assistant = ChatMessage.CreateAssistantMessage(chatCompletion.Content[0].Text);
-                    chatMessages.Add(assistant);
-
-                    //Display the model's response
-                    ShowAssistant(assistant);
-                }
-                catch (Exception e)
-                {
-                    ShowError(e);
-                }
-            } while (true);
-
-            ShowSair();
+          "type": "object",
+          "properties": {
+            "a": { "type": "integer" },
+            "b": { "type": "integer" }
+          },
+          "required": ["a", "b"],
+          "additionalProperties": false
         }
+        """u8.ToArray()));
 
-        static void ShowMenu()
-        {
-            Console.WriteLine(new string('-', 100));
-            Console.WriteLine();
-            Console.WriteLine("Bem-vindo ao Maritaca Chat!");
-            Console.WriteLine();
-            Console.WriteLine(new string('-', 100));
-            Console.WriteLine("Digite 'sair' para encerrar o chat.");
-            Console.WriteLine();
-            Console.WriteLine();
-            Console.WriteLine();
-        }
+List<ChatMessage> messages =
+[
+    new UserChatMessage("Use Multiply para calcular 6 vezes 7.")
+];
+ChatCompletionOptions options = new()
+{
+    ToolChoice = ChatToolChoice.CreateFunctionChoice(nameof(Multiply))
+};
+options.Tools.Add(multiplyTool);
 
-        static string ShowPrompt()
-        {
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.Write($"[{DateTime.Now}] Envie uma mensagem: ");
-            Console.ResetColor();
-            string prompt = Console.ReadLine();
-            if (string.IsNullOrEmpty(prompt))
-            {
-                throw new Exception("Por favor, insira uma mensagem.");
-            }
-            return prompt;
-        }
+ChatCompletion toolRequest = await client.CompleteChatAsync(messages, options);
+if (toolRequest.ToolCalls.Count == 0)
+    throw new InvalidOperationException("O modelo não solicitou uma ferramenta.");
 
-        static void ShowAssistant(AssistantChatMessage assistant)
-        {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine();
-            Console.Write($"[{DateTime.Now}] Assistente: ");
-            Console.ResetColor();
-            Console.WriteLine(assistant.Content[0].Text);
-            Console.WriteLine();
-        }
+messages.Add(new AssistantChatMessage(toolRequest));
+ChatToolCall toolCall = toolRequest.ToolCalls[0];
+using JsonDocument arguments = JsonDocument.Parse(toolCall.FunctionArguments);
+int result = Multiply(
+    arguments.RootElement.GetProperty("a").GetInt32(),
+    arguments.RootElement.GetProperty("b").GetInt32());
+messages.Add(new ToolChatMessage(toolCall.Id, result.ToString()));
 
-        static void ShowError(Exception e)
-        {
-            Console.WriteLine();
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.Write($"[{DateTime.Now}] Erro: ");
-            Console.ResetColor();
-            Console.WriteLine(e.Message);
-            Console.WriteLine();
-        }
-
-        static void ShowSair()
-        {
-            Console.WriteLine(new string('-', 100));
-            Console.WriteLine();
-            Console.WriteLine("Obrigado por usar o Maritaca Chat!");
-            Console.WriteLine();
-            Console.WriteLine();
-        }
-    }
-}
+options.ToolChoice = ChatToolChoice.CreateAutoChoice();
+ChatCompletion final = await client.CompleteChatAsync(messages, options);
+Console.WriteLine($"Resposta com tool: {final.Content[0].Text}"); // 42
 ```
+
 </TabItem>
 </Tabs>
+
+Não dependa apenas de `FinishReason` para detectar uma solicitação: verifique
+se `ToolCalls` contém itens. O mesmo fluxo funciona com `sabia-4` e
+`sabia-4-thinking`.

--- a/documentation/docs/pt/examples/langgraph.md
+++ b/documentation/docs/pt/examples/langgraph.md
@@ -1,42 +1,64 @@
 ---
 id: langgraph
-title: Langgraph
+title: LangGraph
 ---
 
+O `create_agent` do LangChain cria um agente baseado em LangGraph. A API da
+Maritaca pode ser usada por meio do `ChatOpenAI`, configurando o endpoint em
+`base_url`.
 
-## LangGraph + ReAct
+## Instalação
 
-Os modelos da Maritaca funcionam com LangGraph via SDK OpenAI. Configure `base_url`, `api_key` e `model`. Exemplo de agente ReAct com uma ferramenta:
+```bash
+pip install -U langchain langchain-openai langgraph
+export MARITACA_API_KEY="sua-chave-aqui"
+```
+
+O exemplo usa `sabia-4` por padrão. Para usar o modelo de raciocínio, defina
+`MARITACA_MODEL=sabia-4-thinking`.
+
+## Chamada normal e agente com ferramenta
 
 ```python
-# pip install -U langchain-openai langgraph langchain-core
 import os
-from langchain_openai import ChatOpenAI
-from langgraph.prebuilt import create_react_agent
-from langchain_core.messages import HumanMessage
 
+from langchain.agents import create_agent
+from langchain.tools import tool
+from langchain_openai import ChatOpenAI
+
+
+model_name = os.getenv("MARITACA_MODEL", "sabia-4")
 llm = ChatOpenAI(
-    model="sabiazinho-3",
-    api_key=os.environ.get("MARITACA_API_KEY"),
+    model=model_name,
+    api_key=os.environ["MARITACA_API_KEY"],
     base_url="https://chat.maritaca.ai/api",
 )
 
-def add(a: int, b: int) -> int:
-    """Soma a com b.
+normal_response = llm.invoke("Quanto é 25 + 27? Inclua 52 na resposta.")
+print("Chamada normal:", normal_response.content)
 
-    Args:
-        a: primeiro número inteiro
-        b: segundo número inteiro
-    """
+
+@tool
+def add(a: int, b: int) -> int:
+    """Soma dois números inteiros."""
     return a + b
 
-tools = [add]
-react_graph = create_react_agent(llm, tools=tools)
-messages = [HumanMessage(content="Adiciona 12 com 3.")]
-state = react_graph.invoke({"messages": messages})
 
-for m in state["messages"]:
-    m.pretty_print()
+agent = create_agent(
+    model=llm,
+    tools=[add],
+    system_prompt="Sempre use a ferramenta add para fazer somas.",
+)
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "Use add para calcular 12 + 3."}]}
+)
 
+print("Agente:", result["messages"][-1].content)  # 15
+```
 
+O mesmo código funciona com `sabia-4` e `sabia-4-thinking`. O agente executa a
+ferramenta localmente e adiciona o resultado ao histórico antes de pedir a
+resposta final ao modelo.
 
+Para mais detalhes, consulte a
+[documentação de agentes do LangChain](https://docs.langchain.com/oss/python/langchain/agents).

--- a/documentation/docs/pt/examples/llama-index.md
+++ b/documentation/docs/pt/examples/llama-index.md
@@ -1,14 +1,84 @@
 ---
 id: llama-index
-title: Llama-index
+title: LlamaIndex
 ---
 
-Este tutorial MariTalk + LlamaIndex cobre instalação, configuração de chave de API, chat para sugestões de nomes, few-shot com complete para classificação de resenhas e streaming síncrono e assíncrono.
+Use o `OpenAILike` do LlamaIndex para conectar modelos compatíveis com a API da
+OpenAI a um endpoint personalizado.
 
-<div style={{ display: 'flex', justifyContent: 'space-around', margin: '20px 0', flexWrap: 'wrap' }}>
-  <a href="https://docs.llamaindex.ai/en/latest/examples/llm/maritalk/" className="icon-box" style={{ flex: '1 1 200px', margin: '10px', textAlign: 'center' }}>
-    <span className="geo-icon geo-icon-graph" aria-hidden="true"></span>
-    <h3>LlamaIndex</h3>
-    <p>Maritaca no LlamaIndex.</p>
-  </a>
-</div>
+## Instalação
+
+```bash
+pip install -U llama-index-core llama-index-llms-openai-like
+export MARITACA_API_KEY="sua-chave-aqui"
+```
+
+O exemplo usa `sabia-4` por padrão. Para usar o modelo de raciocínio, defina
+`MARITACA_MODEL=sabia-4-thinking`.
+
+## Chamada normal e tools
+
+```python
+import json
+import os
+
+from llama_index.core.llms import ChatMessage
+from llama_index.core.tools import FunctionTool
+from llama_index.llms.openai_like import OpenAILike
+
+
+model_name = os.getenv("MARITACA_MODEL", "sabia-4")
+llm = OpenAILike(
+    model=model_name,
+    api_key=os.environ["MARITACA_API_KEY"],
+    api_base="https://chat.maritaca.ai/api",
+    context_window=128_000,
+    is_chat_model=True,
+    is_function_calling_model=True,
+)
+
+normal_response = llm.chat(
+    [ChatMessage(role="user", content="Quanto é 25 + 27? Inclua 52 na resposta.")]
+)
+print("Chamada normal:", normal_response)
+
+
+def multiply(a: int, b: int) -> int:
+    """Multiplica dois números inteiros."""
+    return a * b
+
+
+tool = FunctionTool.from_defaults(fn=multiply)
+tool_spec = tool.metadata.to_openai_tool()
+messages = [
+    ChatMessage(role="user", content="Use multiply para calcular 6 vezes 7.")
+]
+
+tool_request = llm.chat(
+    messages,
+    tools=[tool_spec],
+    tool_choice={"type": "function", "function": {"name": "multiply"}},
+)
+tool_calls = tool_request.message.additional_kwargs.get("tool_calls", [])
+if not tool_calls:
+    raise RuntimeError("O modelo não solicitou uma ferramenta")
+
+tool_call = tool_calls[0]
+tool_result = tool(**json.loads(tool_call.function.arguments))
+messages.extend(
+    [
+        tool_request.message,
+        ChatMessage(role="tool", content=str(tool_result), additional_kwargs={"tool_call_id": tool_call.id}),
+    ]
+)
+
+final_response = llm.chat(messages, tools=[tool_spec])
+print("Resposta com tool:", final_response)  # 42
+```
+
+Esse tool loop usa apenas APIs públicas do LlamaIndex e funciona com `sabia-4`
+e `sabia-4-thinking`. Sua aplicação recebe a solicitação estruturada, executa a
+função e devolve o resultado como uma mensagem com o mesmo `tool_call_id`.
+
+Para mais detalhes, consulte a
+[documentação do OpenAILike](https://docs.llamaindex.ai/en/stable/api_reference/llms/openai_like/).

--- a/documentation/docs/pt/examples/n8n.md
+++ b/documentation/docs/pt/examples/n8n.md
@@ -3,103 +3,95 @@ id: n8n
 title: n8n
 ---
 
-## Maritaca AI + n8n
+O [n8n](https://n8n.io) pode usar os modelos da Maritaca por meio do sub-nó
+**OpenAI Chat Model**. A configuração abaixo foi validada no n8n 2.30.7 com uma
+chain simples e com um agente que executa uma ferramenta.
 
-O [n8n](https://n8n.io) é uma plataforma de automação de workflows que permite conectar diversas aplicações e serviços. Como a API da Maritaca é compatível com o formato OpenAI, você pode usar o nó **OpenAI Chat Model** do n8n para integrar os modelos Sabiá (por exemplo, Sabiá-4) nos seus workflows.
+## Pré-requisitos
 
-### Pré-requisitos
+- Uma instância do n8n Cloud ou self-hosted.
+- Uma chave criada na
+  [plataforma da Maritaca](https://plataforma.maritaca.ai/chaves-de-api).
 
-- Uma instância do n8n (self-hosted ou n8n Cloud)
-- Uma chave de API da Maritaca ([obtenha aqui](https://chat.maritaca.ai))
+Mantenha o valor de `MARITACA_API_KEY` fora do workflow e salve-o somente em uma
+credencial do n8n.
 
-### Passo 1: Criar a credencial
+## Criar a credencial
 
-1. No n8n, vá em **Settings** > **Credentials** > **Add Credential**
-2. Busque por **OpenAI** e selecione
-3. Preencha os campos:
-   - **API Key:** sua chave de API da Maritaca
-   - **Base URL:** `https://chat.maritaca.ai/api`
-4. Dê um nome descritivo, como **"Maritaca AI"**
-5. Clique em **Save**
+1. Acesse **Settings** > **Credentials** > **Add Credential**.
+2. Busque por **OpenAI**.
+3. Em **API Key**, cole o valor da sua `MARITACA_API_KEY`.
+4. Em **Base URL**, use `https://chat.maritaca.ai/api`.
+5. Salve com um nome como **Maritaca AI**.
 
-:::info
-O botão "Test" da credencial pode mostrar um aviso, pois o n8n tenta validar usando endpoints específicos da OpenAI. Isso não afeta o funcionamento — prossiga normalmente.
-:::
+## Configurar o OpenAI Chat Model
 
-### Passo 2: Configurar o modelo no workflow
+Adicione **OpenAI Chat Model** ao slot **Chat Model** da chain ou do agente e
+configure:
 
-1. Crie um novo workflow e adicione um nó raiz — **AI Agent** (para workflows com ferramentas) ou **Basic LLM Chain** (para chamadas simples)
-2. Clique no **"+"** no slot **Chat Model** do nó raiz
-3. Selecione **OpenAI Chat Model**
-4. Configure:
-   - **Credential:** selecione a credencial "Maritaca AI" criada no Passo 1
-   - **Model:** digite `sabia-4` manualmente (use o modo de expressão caso o dropdown não liste o modelo)
+- **Credential:** `Maritaca AI`.
+- **Model:** selecione o modo **ID** e informe `sabia-4` ou
+  `sabia-4-thinking`.
+- **Use Responses API:** desativado.
 
-:::tip
-Se o dropdown de modelos não carregar, clique no ícone de expressão ao lado do campo e digite o nome do modelo diretamente: `sabia-4`.
-:::
+Desativar **Use Responses API** faz o sub-nó usar Chat Completions, que é o
+fluxo validado nos exemplos abaixo.
 
-### Exemplo 1: Chatbot simples
+## Chamada normal com Basic LLM Chain
 
-Monte o seguinte workflow:
+Monte o workflow:
 
-```
-Chat Trigger → Basic LLM Chain → (saída)
-                     │
-               OpenAI Chat Model
-               (credencial: Maritaca AI)
-               (modelo: sabia-4)
+```text
+Manual Trigger → Basic LLM Chain
+                       │
+                OpenAI Chat Model
 ```
 
-**Passos:**
-1. Adicione um nó **Chat Trigger** (fornece a interface de chat para testes)
-2. Adicione um nó **Basic LLM Chain** e conecte ao Chat Trigger
-3. Anexe o sub-nó **OpenAI Chat Model** ao Basic LLM Chain (via slot Chat Model)
-4. Selecione a credencial Maritaca AI e o modelo `sabia-4`
-5. Clique em **Chat** na parte inferior do canvas para testar
+1. Em **Basic LLM Chain**, escolha **Define below** para o prompt.
+2. Use `Quanto é 25 + 27? Inclua 52 na resposta.`.
+3. Conecte o **OpenAI Chat Model** configurado acima.
+4. Execute o workflow e confira a saída da chain.
 
-### Exemplo 2: Agente com ferramentas
+## Agente com Calculator
 
-```
-Chat Trigger → AI Agent → (saída)
-                  │
-            OpenAI Chat Model  +  Tool nodes  +  Memory
-            (credencial: Maritaca AI)
-            (modelo: sabia-4)
+Monte o workflow:
+
+```text
+Manual Trigger → AI Agent
+                    ├── OpenAI Chat Model
+                    └── Calculator
 ```
 
-**Passos:**
-1. Adicione um nó **Chat Trigger**
-2. Adicione um nó **AI Agent** e conecte ao trigger
-3. Anexe o sub-nó **OpenAI Chat Model** com a credencial Maritaca AI
-4. Adicione **Tool** sub-nós conforme necessário (HTTP Request Tool, Calculator, Code Tool, etc.)
-5. Opcionalmente, adicione um sub-nó de **Memory** (ex: Window Buffer Memory) para manter o histórico da conversa
+1. Em **AI Agent**, escolha **Define below** para o prompt.
+2. Use `Use a ferramenta Calculator para calcular 6 vezes 7.`.
+3. Conecte o **OpenAI Chat Model** no slot **Chat Model**.
+4. Adicione **Calculator** ao slot **Tool**.
+5. Execute o workflow; a resposta final deve incluir `42`.
 
-### Exemplo 3: Chamada HTTP direta (alternativa)
+## Alternativa com HTTP Request
 
-Se preferir controle total sobre a requisição, use o nó **HTTP Request**:
+Para enviar uma chamada direta, configure um nó **HTTP Request**:
 
-1. Adicione um nó **HTTP Request**
-2. Configure:
-   - **Method:** POST
-   - **URL:** `https://chat.maritaca.ai/api/chat/completions`
-   - **Authentication:** Header Auth
-   - **Header Name:** `Authorization`
-   - **Header Value:** `Bearer SUA_CHAVE_API`
-   - **Body (JSON):**
+- **Method:** `POST`.
+- **URL:** `https://chat.maritaca.ai/api/chat/completions`.
+- **Authentication:** `Header Auth`.
+- **Header Name:** `Authorization`.
+- **Header Value:** `Bearer SUA_CHAVE_API`.
+- **Content-Type:** `application/json`.
+- **Body:**
 
 ```json
 {
   "model": "sabia-4",
   "messages": [
-    {"role": "user", "content": "Explique o que é inteligência artificial."}
+    {
+      "role": "user",
+      "content": "Quanto é 25 + 27? Inclua 52 na resposta."
+    }
   ],
-  "max_tokens": 1024
+  "max_tokens": 100
 }
 ```
 
-### Dicas
-
-- **Modelos disponíveis:** `sabia-4`, `sabiazinho-4`, `sabia-3.1`, `sabia-3`, `sabiazinho-3`
-- **Chamada de funções (function calling):** o Sabiá-4 suporta function calling no formato OpenAI, compatível com o nó AI Agent do n8n
-- **Docker:** se o n8n roda em Docker e a API é local, use o IP da máquina host ou `host.docker.internal` ao invés de `localhost`
+Para usar o modelo de raciocínio, troque apenas `model` por
+`sabia-4-thinking`. Não coloque a chave diretamente no JSON do workflow.


### PR DESCRIPTION
## Contexto

Os exemplos fora de LangChain estavam desatualizados: APIs antigas do LangGraph, tutorial externo do LlamaIndex, modelos antigos no n8n, exemplos C#/JavaScript inconsistentes e links incorretos no README.

## Alterações

- LangGraph: create_agent atual, chamada normal e tool calling
- LlamaIndex: OpenAILike, chamada normal e loop público de tools
- JavaScript: SDK oficial OpenAI com chamada normal e tools
- C#: pacote oficial OpenAI com chamada normal e tools
- n8n: configuração validada no n8n 2.30.7, Basic LLM Chain, AI Agent com Calculator e HTTP Request
- exemplos PT/EN para sabia-4 e sabia-4-thinking
- correção dos links de C#/JavaScript e LlamaIndex no README

## Validação

- 33 testes estáticos passaram
- 22 testes reais passaram com a API:
  - snippets Python de LangGraph e LlamaIndex em PT/EN e nos dois modelos
  - snippets JavaScript em PT/EN e nos dois modelos
  - snippets C# em PT/EN e nos dois modelos
  - requisições n8n em PT/EN e nos dois modelos
  - workflows reais Basic LLM Chain e AI Agent com Calculator no n8n 2.30.7
- build Docusaurus completo para PT e EN passou
- links externos e internos retornaram HTTP 200
- git diff --check e varredura de segredo passaram

Versões validadas: langchain 1.3.14, langchain-openai 1.3.5, langgraph 1.2.9, llama-index-core 0.14.23, llama-index-llms-openai-like 0.7.2, openai Python 2.46.0, openai JavaScript 6.48.0, OpenAI .NET 2.12.0 e n8n 2.30.7.

## Curadoria dos testes

O harness temporário foi usado para executar todos os snippets exatamente como publicados, mas não foi incluído na PR porque depende de credencial paga, Docker, .NET, n8n e SDKs opcionais que não fazem parte do CI atual. O build Docusaurus permanece como a validação reproduzível do repositório.