### PR TITLE
[codex] Document web search domain filters

### DIFF
--- a/documentation/api/en/completion.md
+++ b/documentation/api/en/completion.md
@@ -107,6 +107,24 @@ Default is `0.95`. If less than 1, only the top tokens with cumulative probabili
 A list of tools the model can call. Use this parameter to provide a list of functions for which the model can generate JSON inputs.
 
 ---
+### web_search `bool or null` <sup class="sup-opcional">Optional</sup>
+Default is `false`. If `true`, allows the model to search and read web pages.
+Web search requires `stream: false`.
+
+---
+### web_search_filters `object or null` <sup class="sup-opcional">Optional</sup>
+Optional filters used when `web_search` is enabled.
+
+- **allowed_domains** (array of strings): Keeps only results from these domains. Maximum 100.
+- **blocked_domains** (array of strings): Excludes results from these domains. Maximum 100.
+
+When both lists are used, `allowed_domains` restricts the result set and
+`blocked_domains` removes results from that set, taking precedence. Provide
+domains without a protocol, port, or path. Each domain also includes its
+subdomains. With the OpenAI SDK, pass `web_search` and `web_search_filters`
+through `extra_body`.
+
+---
 ### tool_choice `string or object` <sup class="sup-opcional">Optional</sup>
 Controls which (if any) tool the model calls.
   - `"none"`: the model will not call any tool and will instead generate a message.

--- a/documentation/api/en/responses-api.md
+++ b/documentation/api/en/responses-api.md
@@ -86,16 +86,41 @@ Default is `false`. If `true`, returns the response via Server-Sent Events in re
 
 ---
 ### tools `array or null` <sup class="sup-opcional">Optional</sup>
-List of tools (functions) the model can call. Each tool has the format:
+List of tools the model can call. Accepts functions and built-in tools,
+including `web_search`.
 
 <details>
-<summary>Tool object format</summary>
+<summary>Function format</summary>
 
 - **type** (string): Always `"function"`.
 - **name** (string) **Required**: Function name.
 - **description** (string): Function description.
 - **parameters** (object): JSON Schema of the parameters.
 - **strict** (bool): If `true`, enables strict schema validation. Default: `true`.
+
+</details>
+
+<details>
+<summary>Web search format</summary>
+
+- **type** (string) **Required**: Always `"web_search"`.
+- **filters** (object): Optional domain filters.
+  - **allowed_domains** (array of strings): Keeps only results from these domains. Maximum 100.
+  - **blocked_domains** (array of strings): Excludes results from these domains. Maximum 100.
+
+When both lists are used, `allowed_domains` restricts the result set and
+`blocked_domains` removes results from that set, taking precedence. Provide
+domains without a protocol, port, or path. Each domain also includes its
+subdomains. Web search requires `stream: false`.
+
+```json
+{
+  "type": "web_search",
+  "filters": {
+    "allowed_domains": ["stf.jus.br", "gov.br"]
+  }
+}
+```
 
 </details>
 

--- a/documentation/api/pt/completion.md
+++ b/documentation/api/pt/completion.md
@@ -106,6 +106,24 @@ Padrão é `0.95`. Se menor que 1, mantém apenas os tokens superiores com proba
 Uma lista de ferramentas que o modelo pode chamar. Use esse parâmetro para fornecer uma lista de funções para as quais o modelo pode gerar entradas JSON.
 
 ---
+### web_search `bool ou null` <sup class="sup-opcional">Opcional</sup>
+Padrão é `false`. Se `true`, permite que o modelo pesquise e leia páginas da
+web. A busca na web exige `stream: false`.
+
+---
+### web_search_filters `object ou null` <sup class="sup-opcional">Opcional</sup>
+Filtros opcionais usados quando `web_search` está ativo.
+
+- **allowed_domains** (array de strings): Mantém apenas resultados destes domínios. Máximo de 100.
+- **blocked_domains** (array de strings): Exclui resultados destes domínios. Máximo de 100.
+
+Quando as duas listas são usadas, `allowed_domains` restringe o conjunto de
+resultados e `blocked_domains` remove resultados desse conjunto, tendo
+precedência. Informe apenas domínios, sem protocolo, porta ou caminho. Cada
+domínio também inclui seus subdomínios. Com a biblioteca da OpenAI, envie
+`web_search` e `web_search_filters` por `extra_body`.
+
+---
 ### tool_choice `string ou object` <sup class="sup-opcional">Opcional</sup>
 Controla qual (se houver) ferramenta é chamada pelo modelo.
   - `"none"`: o modelo não chamará nenhuma ferramenta e, em vez disso, gerará uma mensagem.

--- a/documentation/api/pt/responses-api.md
+++ b/documentation/api/pt/responses-api.md
@@ -86,16 +86,41 @@ Padrão é `false`. Se `true`, retorna a resposta via Server-Sent Events em temp
 
 ---
 ### tools `array ou null` <sup class="sup-opcional">Opcional</sup>
-Lista de ferramentas (funções) que o modelo pode chamar. Cada tool tem o formato:
+Lista de ferramentas que o modelo pode chamar. Aceita funções e ferramentas
+integradas, incluindo `web_search`.
 
 <details>
-<summary>Formato do objeto Tool</summary>
+<summary>Formato de uma função</summary>
 
 - **type** (string): Sempre `"function"`.
 - **name** (string) **Obrigatório**: Nome da função.
 - **description** (string): Descrição da função.
 - **parameters** (object): JSON Schema dos parâmetros.
 - **strict** (bool): Se `true`, ativa validação estrita do schema. Padrão: `true`.
+
+</details>
+
+<details>
+<summary>Formato da busca na web</summary>
+
+- **type** (string) **Obrigatório**: Sempre `"web_search"`.
+- **filters** (object): Filtros opcionais de domínio.
+  - **allowed_domains** (array de strings): Mantém apenas resultados destes domínios. Máximo de 100.
+  - **blocked_domains** (array de strings): Exclui resultados destes domínios. Máximo de 100.
+
+Quando as duas listas são usadas, `allowed_domains` restringe o conjunto de
+resultados e `blocked_domains` remove resultados desse conjunto, tendo
+precedência. Informe apenas domínios, sem protocolo, porta ou caminho. Cada
+domínio também inclui seus subdomínios. A busca na web exige `stream: false`.
+
+```json
+{
+  "type": "web_search",
+  "filters": {
+    "allowed_domains": ["stf.jus.br", "gov.br"]
+  }
+}
+```
 
 </details>
 

--- a/documentation/docs/en/tools.md
+++ b/documentation/docs/en/tools.md
@@ -107,6 +107,48 @@ The built-in tool types map to the flags as follows:
 
 You can mix built-in tools with your own [function tools](function-call.md) in the same request.
 
+## Filtering web search sources
+
+You can restrict search to specific domains with `allowed_domains` and exclude
+domains with `blocked_domains`. Each list accepts up to 100 domains. When both
+are used, search first keeps only allowed domains and then removes blocked
+ones; `blocked_domains` takes precedence. Provide the domain only, without a
+protocol, port, or path. A domain also includes its subdomains.
+
+On the Responses API, use `filters` inside the `web_search` tool:
+
+```python
+response = client.responses.create(
+    model="sabia-4",
+    input="What are the latest decisions from Brazil's Supreme Court on this topic?",
+    tools=[{
+        "type": "web_search",
+        "filters": {"allowed_domains": ["stf.jus.br"]},
+    }],
+)
+```
+
+On Chat Completions, pass the filter through the `web_search_filters`
+extension:
+
+```python
+response = client.chat.completions.create(
+    model="sabia-4",
+    stream=False,
+    messages=[{"role": "user", "content": "Search for news about this topic."}],
+    extra_body={
+        "web_search": True,
+        "web_search_filters": {
+            "blocked_domains": ["example.com"],
+        },
+    },
+)
+```
+
+`allowed_domains` keeps only results from the specified domains;
+`blocked_domains` removes results from those domains. When no filter is sent,
+web search continues without domain restrictions.
+
 ## What you get back
 
 ### Usage metering

--- a/documentation/docs/pt/ferramentas.md
+++ b/documentation/docs/pt/ferramentas.md
@@ -107,6 +107,48 @@ Os tipos de ferramenta integrada são mapeados para as flags da seguinte forma:
 
 Você pode combinar ferramentas integradas com as suas próprias [ferramentas de função](chamada-funcao.md) na mesma requisição.
 
+## Filtrando fontes da busca na web
+
+Você pode restringir a busca a determinados domínios com `allowed_domains` e
+excluir domínios com `blocked_domains`. Cada lista aceita até 100 domínios.
+Quando ambas são usadas, a busca mantém apenas os domínios permitidos e depois
+remove os bloqueados; `blocked_domains` tem precedência. Informe apenas o
+domínio, sem protocolo, porta ou caminho. Um domínio também inclui seus
+subdomínios.
+
+Na Responses API, use `filters` dentro da ferramenta `web_search`:
+
+```python
+response = client.responses.create(
+    model="sabia-4",
+    input="Quais foram as decisões recentes do STF sobre o tema?",
+    tools=[{
+        "type": "web_search",
+        "filters": {"allowed_domains": ["stf.jus.br"]},
+    }],
+)
+```
+
+Em Chat Completions, envie o filtro pela extensão `web_search_filters`:
+
+```python
+response = client.chat.completions.create(
+    model="sabia-4",
+    stream=False,
+    messages=[{"role": "user", "content": "Pesquise notícias sobre o tema."}],
+    extra_body={
+        "web_search": True,
+        "web_search_filters": {
+            "blocked_domains": ["example.com"],
+        },
+    },
+)
+```
+
+`allowed_domains` mantém apenas resultados dos domínios informados;
+`blocked_domains` remove resultados desses domínios. Quando nenhum filtro é
+enviado, a busca continua consultando a web sem restrição de domínio.
+
 ## O que você recebe de volta
 
 ### Medição de uso


### PR DESCRIPTION
## Summary

- document `allowed_domains` and `blocked_domains` for web search;
- cover the Responses API and Chat Completions request formats;
- explain limits, subdomain matching, and blocklist precedence when both filters are used;
- add matching Portuguese and English reference content and examples.

## Validation

- Docusaurus production build completed for `pt` and `en`;
- `git diff --check` passed.
