### PR TITLE
docs: fix Batch API examples importing OpenAI but calling openai.OpenAI

### DIFF
--- a/documentation/api/pt/batch-api.md
+++ b/documentation/api/pt/batch-api.md
@@ -130,7 +130,7 @@ atualmente apenas `batch_input` é aceito
 <TabItem value="python" label="Default" default>
 
 ```python
-from openai import OpenAI
+import openai
 
 client = openai.OpenAI(
     api_key="", #Sua API_KEY

--- a/documentation/docs/en/api/quick-start.md
+++ b/documentation/docs/en/api/quick-start.md
@@ -115,7 +115,7 @@ model = maritalk.MariTalk(
   import openai
 
   model = openai.OpenAI(
-    api_key="my_key",,
+    api_key="my_key",
     base_url="https://chat.maritaca.ai/api",
   )
 

--- a/documentation/docs/en/batch_api.md
+++ b/documentation/docs/en/batch_api.md
@@ -58,7 +58,7 @@ For each batch, use a single `.jsonl` file: each line corresponds to one API req
 ### 2. Uploading the Batch Input File
 Send your .jsonl file using the endpoint below. Files can contain at most 50,000 requests and must be no larger than 200MB each.
 ```python
-from openai import OpenAI
+import openai
 
 client = openai.OpenAI(
     api_key="",  # Your API_KEY
@@ -78,7 +78,7 @@ print(batch_input_file)
 Use the file ID (for example, file1) to create the batch. The completion_window is fixed at 24h, and you can include extra metadata via the metadata parameter. Example:
 
 ```python
-from openai import OpenAI
+import openai
 client = openai.OpenAI(
     api_key="",  # Your API_KEY
     base_url="https://chat.maritaca.ai/api",
@@ -126,7 +126,7 @@ This request will return a Batch object with metadata about your batch:
 
 It's possible to check a batch's status at any time, and you'll also receive the corresponding Batch object as part of that process.
 ```python 
-from openai import OpenAI
+import openai
 client = openai.OpenAI(
     api_key="",  # Your API_KEY
     base_url="https://chat.maritaca.ai/api",
@@ -153,7 +153,7 @@ Each Batch object can have one of the following status:
 When the batch has finished processing, you can obtain the output by sending a request to the API using the output_file_id from the Batch object. After receiving the file, save it locally (for example, as batch_output.jsonl).
 
 ```python
-from openai import OpenAI
+import openai
 client = openai.OpenAI(
     api_key="",  # Your# API_KEY
     base_url="https://chat.maritaca.ai/api",
@@ -181,7 +181,7 @@ Canceling a batch:
 
 ```python
 
-from openai import OpenAI
+import openai
 client = openai.OpenAI(
     api_key="",  # Your API_KEY
     base_url="https://chat.maritaca.ai/api",
@@ -194,7 +194,7 @@ client.batches.cancel("batch1")
 You can view all of your batches at any point in time. If you have a large number of batches, you can use the limit and after parameters to paginate your results.
 
 ```python
-from openai import OpenAI
+import openai
 client = openai.OpenAI(
     api_key="",  # Your API_KEY
     base_url="https://chat.maritaca.ai/api",

--- a/documentation/docs/pt/api/comeco-rapido.md
+++ b/documentation/docs/pt/api/comeco-rapido.md
@@ -116,7 +116,7 @@ model = maritalk.MariTalk(
   import openai
 
   model = openai.OpenAI(
-    api_key="minha_chave",,
+    api_key="minha_chave",
     base_url="https://chat.maritaca.ai/api",
   )
 

--- a/documentation/docs/pt/batch_api.md
+++ b/documentation/docs/pt/batch_api.md
@@ -60,7 +60,7 @@ Para cada lote use um único arquivo .jsonl: cada linha corresponde a uma solici
 Envie seu arquivo .jsonl usando o endpoint abaixo. Os arquivos podem conter no máximo 50.000 requisições e não devem ultrapassar 200MB cada.
 
 ```python
-from openai import OpenAI
+import openai
 
 client = openai.OpenAI(
     api_key="", #Sua API_KEY
@@ -84,7 +84,7 @@ print(batch_input_file)
 Use o ID do arquivo (por exemplo, file1) para criar o lote. O completion_window é fixo em 24h, e você pode fornecer metadados extras por meio do parâmetro metadata. Exemplo:
 
 ```python
-from openai import OpenAI
+import openai
 client = openai.OpenAI(
     api_key="", #Sua API_KEY
     base_url="https://chat.maritaca.ai/api",
@@ -135,8 +135,7 @@ Essa requisição retornará um objeto Batch com as informações sobre o lote:
 
 
 ```python
-from openai import OpenAI
-from openai import OpenAI
+import openai
 client = openai.OpenAI(
     api_key="", #Sua API_KEY
     base_url="https://chat.maritaca.ai/api",
@@ -165,7 +164,7 @@ Cada objeto Batch pode ter um dos seguintes status:
 Quando o lote tiver sido processado, você pode obter o arquivo de saída enviando uma requisição para a API utilizando o output_file_id do objeto Batch. Depois de receber o arquivo, salve-o localmente (por exemplo, como batch_output.jsonl).
 
 ```python
-from openai import OpenAI
+import openai
 client = openai.OpenAI(
     api_key="", #Sua API_KEY
     base_url="https://chat.maritaca.ai/api",
@@ -190,7 +189,7 @@ Se necessário, é possível cancelar um lote que esteja em execução. Durante 
 Cancelando um lote:
 
 ```python
-from openai import OpenAI
+import openai
 client = openai.OpenAI(
     api_key="", #Sua API_KEY
     base_url="https://chat.maritaca.ai/api",
@@ -202,7 +201,7 @@ client.batches.cancel("batch1")
 Você pode visualizar todos os seus lotes a qualquer momento. Se possuir muitos lotes, utilize os parâmetros limit e after para paginar os resultados.
 
 ```python
-from openai import OpenAI
+import openai
 client = openai.OpenAI(
     api_key="", #Sua API_KEY
     base_url="https://chat.maritaca.ai/api",


### PR DESCRIPTION
## Summary
- **Batch API (PT/EN, docs e referência da API)**: exemplos faziam `from openai import OpenAI` mas chamavam `openai.OpenAI(...)`, gerando `NameError` ao copiar o trecho isolado. Padronizado para `import openai`, como no restante da documentação.
- Removido import duplicado no exemplo de consulta de status (PT).
- **Começo Rápido / Quick Start**: corrigida vírgula dupla em `api_key="...",,`.

Todos os blocos Python das páginas de Batch foram verificados com `ast.parse`.

## Test plan
- [ ] Verificar https://docs.maritaca.ai/pt/batch-api e a versão EN: copiar um exemplo e rodar

🤖 Generated with [Claude Code](https://claude.com/claude-code)