### PR TITLE
docs: Sabiá 4 Thinking anuncia 1M de tokens de contexto

### DIFF
--- a/documentation/api/en/list-models-response.md
+++ b/documentation/api/en/list-models-response.md
@@ -69,9 +69,9 @@ Information about the primary provider, including `context_length` and `max_comp
       "created": 1781049600,
       "object": "model",
       "owned_by": "maritacaai",
-      "context_length": 128000,
+      "context_length": 1000000,
       "top_provider": {
-        "context_length": 128000,
+        "context_length": 1000000,
         "max_completion_tokens": 32768
       }
     },

--- a/documentation/api/pt/list-models-response.md
+++ b/documentation/api/pt/list-models-response.md
@@ -70,9 +70,9 @@ Informações do provedor principal, incluindo `context_length` e `max_completio
       "created": 1781049600,
       "object": "model",
       "owned_by": "maritacaai",
-      "context_length": 128000,
+      "context_length": 1000000,
       "top_provider": {
-        "context_length": 128000,
+        "context_length": 1000000,
         "max_completion_tokens": 32768
       }
     },

--- a/documentation/docs/en/models.md
+++ b/documentation/docs/en/models.md
@@ -43,7 +43,7 @@ The same Sabiazinho 4 model, with **inference and processing performed entirely 
 
 | | **Sabiá 4 Thinking** | **Sabiá 4 Thinking BR-SP** | **Sabiá 4** | **Sabiá 4 BR-SP** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
 |---|---|---|---|---|---|---|
-| **Max context** | 1M | 128K | 128K | 128K | 128K | 128K |
+| **Max context** | 1M | 1M | 128K | 128K | 128K | 128K |
 | **Max output tokens** | 32K | 32K | 32K | 32K | 32K | 32K |
 | **Model names/aliases** | sabia-4-thinking | sabia-4-thinking-br-sp | sabia-4<br />sabia-4-2026-01-06 | sabia-4-br-sp | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
 

--- a/documentation/docs/en/models.md
+++ b/documentation/docs/en/models.md
@@ -11,7 +11,7 @@ Maritaca AI offers a range of models in the Sabiá family, designed to meet vari
 
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4 Thinking</span></span>
 
-The reasoning model of the Sabiá family, delivering frontier quality in Portuguese and Brazilian contexts at the lowest cost among the evaluated models. Compared to Sabiá 4, it brings significant gains in tool use, legal tasks, and answer quality. Recommended for complex tasks that benefit from explicit reasoning before answering.
+The reasoning model of the Sabiá family, delivering frontier quality in Portuguese and Brazilian contexts at the lowest cost among the evaluated models. Compared to Sabiá 4, it brings significant gains in tool use, legal tasks, and answer quality. Recommended for complex tasks that benefit from explicit reasoning before answering. Supports up to **1 million tokens of context**, so long documents, entire case files or whole knowledge bases fit in a single request (also available through the Batch API).
 
 **Example use cases:** Multi-step problem solving, agentic workflows and tool use, legal analysis and drafting, and exam questions and technical reasoning.
 
@@ -43,7 +43,7 @@ The same Sabiazinho 4 model, with **inference and processing performed entirely 
 
 | | **Sabiá 4 Thinking** | **Sabiá 4 Thinking BR-SP** | **Sabiá 4** | **Sabiá 4 BR-SP** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
 |---|---|---|---|---|---|---|
-| **Max context** | 128K | 128K | 128K | 128K | 128K | 128K |
+| **Max context** | 1M | 128K | 128K | 128K | 128K | 128K |
 | **Max output tokens** | 32K | 32K | 32K | 32K | 32K | 32K |
 | **Model names/aliases** | sabia-4-thinking | sabia-4-thinking-br-sp | sabia-4<br />sabia-4-2026-01-06 | sabia-4-br-sp | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
 

--- a/documentation/docs/pt/modelos.md
+++ b/documentation/docs/pt/modelos.md
@@ -43,7 +43,7 @@ O mesmo modelo Sabiazinho 4, com **inferência e processamento realizados 100% e
 
 | | **Sabiá 4 Thinking** | **Sabiá 4 Thinking BR-SP** | **Sabiá 4** | **Sabiá 4 BR-SP** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
 |---|---|---|---|---|---|---|
-| **Contexto máximo** | 1M | 128K | 128K | 128K | 128K | 128K |
+| **Contexto máximo** | 1M | 1M | 128K | 128K | 128K | 128K |
 | **Máximo de tokens de saída** | 32K | 32K | 32K | 32K | 32K | 32K |
 | **Nomes aceitos (alias)** | sabia-4-thinking | sabia-4-thinking-br-sp | sabia-4<br />sabia-4-2026-01-06 | sabia-4-br-sp | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
 

--- a/documentation/docs/pt/modelos.md
+++ b/documentation/docs/pt/modelos.md
@@ -11,7 +11,7 @@ A Maritaca AI oferece uma gama de modelos na família Sabiá, projetados para at
 
 ### <span className="inline-title"><span className="geo-icon geo-icon-sabiazinho4 geo-icon-small" aria-hidden="true"></span><span>Sabiá 4 Thinking</span></span>
 
-Modelo de raciocínio da família Sabiá, com qualidade de fronteira em português e contextos brasileiros pelo menor custo entre os modelos avaliados. Em relação ao Sabiá 4, traz ganhos expressivos em uso de ferramentas, tarefas jurídicas e qualidade das respostas. Indicado para tarefas complexas que se beneficiam de raciocínio explícito antes da resposta.
+Modelo de raciocínio da família Sabiá, com qualidade de fronteira em português e contextos brasileiros pelo menor custo entre os modelos avaliados. Em relação ao Sabiá 4, traz ganhos expressivos em uso de ferramentas, tarefas jurídicas e qualidade das respostas. Indicado para tarefas complexas que se beneficiam de raciocínio explícito antes da resposta. Suporta até **1 milhão de tokens de contexto**, o que permite enviar documentos extensos, processos completos ou bases de conhecimento inteiras em um único request (disponível também na Batch API).
 
 **Exemplos de uso:** Resolução de problemas com múltiplas etapas, fluxos agênticos e uso de ferramentas, análise e redação jurídica, e questões de exames e raciocínio técnico.
 
@@ -43,7 +43,7 @@ O mesmo modelo Sabiazinho 4, com **inferência e processamento realizados 100% e
 
 | | **Sabiá 4 Thinking** | **Sabiá 4 Thinking BR-SP** | **Sabiá 4** | **Sabiá 4 BR-SP** | **Sabiazinho 4** | **Sabiazinho 4 BR-SP** |
 |---|---|---|---|---|---|---|
-| **Contexto máximo** | 128K | 128K | 128K | 128K | 128K | 128K |
+| **Contexto máximo** | 1M | 128K | 128K | 128K | 128K | 128K |
 | **Máximo de tokens de saída** | 32K | 32K | 32K | 32K | 32K | 32K |
 | **Nomes aceitos (alias)** | sabia-4-thinking | sabia-4-thinking-br-sp | sabia-4<br />sabia-4-2026-01-06 | sabia-4-br-sp | sabiazinho-4<br />sabiazinho-4-2026-01-06<br />sabia-4-small<br />sabiazim-4 | sabiazinho-4-br-sp |
 


### PR DESCRIPTION
## O que muda

- Tabela de especificações (pt/en): **Contexto máximo** do Sabiá 4 Thinking passa de 128K para **1M**; demais modelos seguem em 128K.
- Descrição do Sabiá 4 Thinking ganha uma frase sobre o contexto de 1 milhão de tokens (disponível também na Batch API).
- Exemplos do `/v1/models` (pt/en): `context_length` do `sabia-4-thinking` passa a 1000000.

Rate limits não mudam (o "128k" daquela página é TPM, não contexto). Nenhuma menção a mecanismo interno.

## Depende de

maritaca-ai/maritalk `feat/long-context-1m-catalog-batch` (catálogo da API/plataforma passa a expor 1M e a Batch API passa a aceitar inputs acima de 128k no sabia-4-thinking). Publicar junto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)